### PR TITLE
Changing parameter welcomeMessage to welcome in CreateMeetingParameters

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -378,7 +378,7 @@ class CreateMeetingParameters extends BaseParameters
                   'record'             => $this->record,
                   'autoStartRecording' => $this->autoStartRecording,
                   'duration'           => $this->duration,
-                  'welcomeMessage'     => trim($this->welcomeMessage),
+                  'welcome'     => trim($this->welcomeMessage),
             ]
         );
     }


### PR DESCRIPTION
The welcomeMessage not override the original parameter and not change the welcome message. After I changed this parameter name from "welcomeMessage" to "welcome" the parameter worked well.