### PR TITLE
Fixed API Call for getMeetingInfo

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -215,7 +215,7 @@ class BigBlueButton
      */
     public function getMeetingInfoUrl($meetingParams)
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::IS_MEETING_RUNNING, $meetingParams->getHTTPQuery());
+        return $this->urlBuilder->buildUrl(ApiMethod::GET_MEETING_INFO, $meetingParams->getHTTPQuery());
     }
 
     /**


### PR DESCRIPTION
The function was using "ApiMethod::IS_MEETING_RUNNING" instead of "ApiMethod::GET_MEETING_INFO" which would return the incorrect xml response for said function.