### PR TITLE
Implementation of setConfigXML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
 
 script:
   - mkdir -p build/logs
-  - if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then phpunit; fi
   - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then phpunit --coverage-clover build/logs/clover.xml; fi
   - if [ "$TRAVIS_PHP_VERSION" == "nightly" ]; then phpunit; fi
 

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -439,6 +439,7 @@ class CreateMeetingParameters extends MetaParameters
     public function getPresentationsAsXML()
     {
         $result = '';
+
         if (!empty($this->presentations)) {
             $xml    = new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><modules/>');
             $module = $xml->addChild('module');

--- a/src/Parameters/SetConfigXMLParameters.php
+++ b/src/Parameters/SetConfigXMLParameters.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Parameters;
+
+/**
+ * Class SetConfigXMLParameters
+ * @package BigBlueButton\Parameters
+ */
+class SetConfigXMLParameters extends BaseParameters
+{
+    /**
+     * @var string
+     */
+    private $meetingId;
+
+    /**
+     * @var \SimpleXMLElement
+     */
+    private $rawXml;
+
+    /**
+     * SetConfigXMLParameters constructor.
+     *
+     * @param $meetingId
+     */
+    public function __construct($meetingId)
+    {
+        $this->meetingId = $meetingId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMeetingId()
+    {
+        return $this->meetingId;
+    }
+
+    /**
+     * @param  string                 $meetingId
+     * @return SetConfigXMLParameters
+     */
+    public function setMeetingId($meetingId)
+    {
+        $this->meetingId = $meetingId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRawXml()
+    {
+        return $this->rawXml;
+    }
+
+    /**
+     * @param  \SimpleXMLElement      $rawXml
+     * @return SetConfigXMLParameters
+     */
+    public function setRawXml($rawXml)
+    {
+        $this->rawXml = $rawXml;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHTTPQuery()
+    {
+        return $this->buildHTTPQuery(
+            [
+                'configXML' => urlencode($this->rawXml->asXML()),
+                'meetingID' => $this->meetingId,
+            ]
+        );
+    }
+}

--- a/src/Responses/SetConfigXMLResponse.php
+++ b/src/Responses/SetConfigXMLResponse.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Responses;
+
+/**
+ * Class SetConfigXMLResponse
+ * @package BigBlueButton\Parameters
+ */
+class SetConfigXMLResponse extends BaseResponse
+{
+    /**
+     * @return bool
+     */
+    public function getToken()
+    {
+        return $this->rawXml->token->__toString();
+    }
+}

--- a/src/Util/UrlBuilder.php
+++ b/src/Util/UrlBuilder.php
@@ -46,15 +46,29 @@ class UrlBuilder
     }
 
     /**
-     * Builds an API method URL and generates its checksum.
+     * Builds an API method URL that includes the url + params + its generated checksum.
      *
      * @param string $method
      * @param string $params
+     * @param string $append
      *
      * @return string
      */
-    public function buildUrl($method = '', $params = '')
+    public function buildUrl($method = '', $params = '', $append = true)
     {
-        return $this->bbbServerBaseUrl.'api/'.$method.'?'.$params.'&checksum='.sha1($method.$params.$this->securitySalt);
+        return $this->bbbServerBaseUrl.'api/'.$method.($append ? '?'.$this->buildQs($method, $params) : '');
     }
+
+     /**
+      * Builds a query string for an API method URL that includes the params + its generated checksum.
+      *
+      * @param string $method
+      * @param string $params
+      *
+      * @return string
+      */
+     public function buildQs($method = '', $params = '')
+     {
+         return $params.'&checksum='.sha1($method.$params.$this->securitySalt);
+     }
 }

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -148,7 +148,7 @@ class BigBlueButtonTest extends TestCase
         $this->bbb->joinMeeting($joinMeetingMock);
     }
 
-    /* Default Config XML */
+    /* Get Default Config XML */
 
     public function testGetDefaultConfigXMLUrl()
     {
@@ -160,6 +160,36 @@ class BigBlueButtonTest extends TestCase
     {
         $result = $this->bbb->getDefaultConfigXML();
         $this->assertNotNull($result->getRawXml());
+    }
+
+    /* Set Config XML */
+
+    public function testSetConfigXMLUrl()
+    {
+        $url = $this->bbb->setConfigXMLUrl();
+        $this->assertContains(ApiMethod::SET_CONFIG_XML, $url);
+    }
+
+    public function testSetConfigXML()
+    {
+        // Fetch the Default Config XML file
+        $defaultConfigXMLResponse = $this->bbb->getDefaultConfigXML();
+
+        // Modify the XML file if required
+
+        // Create a meeting
+        $params                = $this->generateCreateParams();
+        $createMeetingResponse = $this->bbb->createMeeting($this->getCreateParamsMock($params));
+        $this->assertEquals('SUCCESS', $createMeetingResponse->getReturnCode());
+
+        // Execute setConfigXML request
+        $params             = ['meetingId' => $createMeetingResponse->getMeetingId()];
+        $setConfigXMLParams = $this->getSetConfigXMLMock($params);
+        $setConfigXMLParams = $setConfigXMLParams->setRawXml($defaultConfigXMLResponse->getRawXml());
+
+        $result = $this->bbb->setConfigXML($setConfigXMLParams);
+        $this->assertEquals('SUCCESS', $result->getReturnCode());
+        $this->assertNotNull($result->getRawXml()->token->__toString());
     }
 
     /* End Meeting */

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -74,7 +74,7 @@ class BigBlueButtonTest extends TestCase
     public function testCreateMeetingUrl()
     {
         $params = $this->generateCreateParams();
-        $url    = $this->bbb->getCreateMeetingUrl($this->getCreateParamsMock($params));
+        $url    = $this->bbb->getCreateMeetingUrl($this->getCreateMock($params));
         foreach ($params as $key => $value) {
             $value = !is_bool($value) ? $value : ($value ? 'true' : 'false');
             $this->assertContains('=' . urlencode($value), $url);
@@ -87,7 +87,7 @@ class BigBlueButtonTest extends TestCase
     public function testCreateMeeting()
     {
         $params = $this->generateCreateParams();
-        $result = $this->bbb->createMeeting($this->getCreateParamsMock($params));
+        $result = $this->bbb->createMeeting($this->getCreateMock($params));
         $this->assertEquals('SUCCESS', $result->getReturnCode());
     }
 
@@ -96,7 +96,7 @@ class BigBlueButtonTest extends TestCase
      */
     public function testCreateMeetingWithDocumentUrl()
     {
-        $params = $this->getCreateParamsMock($this->generateCreateParams());
+        $params = $this->getCreateMock($this->generateCreateParams());
         $params->addPresentation('https://placeholdit.imgix.net/~text?txtsize=96&bg=30406B&txtclr=ffffff&txt=BigBlueButton&w=800&h=600');
 
         $result = $this->bbb->createMeeting($params);
@@ -110,7 +110,7 @@ class BigBlueButtonTest extends TestCase
      */
     public function testCreateMeetingWithDocumentEmbdded()
     {
-        $params = $this->getCreateParamsMock($this->generateCreateParams());
+        $params = $this->getCreateMock($this->generateCreateParams());
         $params->addPresentation('bbb_logo.png', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'bbb_logo.png'));
 
         $result = $this->bbb->createMeeting($params);
@@ -179,17 +179,18 @@ class BigBlueButtonTest extends TestCase
 
         // Create a meeting
         $params                = $this->generateCreateParams();
-        $createMeetingResponse = $this->bbb->createMeeting($this->getCreateParamsMock($params));
+        $createMeetingResponse = $this->bbb->createMeeting($this->getCreateMock($params));
         $this->assertEquals('SUCCESS', $createMeetingResponse->getReturnCode());
 
         // Execute setConfigXML request
         $params             = ['meetingId' => $createMeetingResponse->getMeetingId()];
         $setConfigXMLParams = $this->getSetConfigXMLMock($params);
         $setConfigXMLParams = $setConfigXMLParams->setRawXml($defaultConfigXMLResponse->getRawXml());
+        $this->assertEquals($setConfigXMLParams->getRawXml(), $defaultConfigXMLResponse->getRawXml());
 
         $result = $this->bbb->setConfigXML($setConfigXMLParams);
         $this->assertEquals('SUCCESS', $result->getReturnCode());
-        $this->assertNotNull($result->getRawXml()->token->__toString());
+        $this->assertNotNull($result->getToken());
     }
 
     /* End Meeting */

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -29,7 +29,7 @@ class CreateMeetingParametersTest extends TestCase
     public function testCreateMeetingParameters()
     {
         $params              = $this->generateCreateParams();
-        $createMeetingParams = $this->getCreateParamsMock($params);
+        $createMeetingParams = $this->getCreateMock($params);
 
         $this->assertEquals($params['meetingName'], $createMeetingParams->getMeetingName());
         $this->assertEquals($params['meetingId'], $createMeetingParams->getMeetingId());

--- a/tests/Parameters/SetConfigXMLParametersTest.php
+++ b/tests/Parameters/SetConfigXMLParametersTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Parameters;
+
+use BigBlueButton\TestCase as TestCase;
+
+/**
+ * Class SetConfigXMLParametersTest
+ * @package BigBlueButton\Parameters
+ */
+class SetConfigXMLParametersTest extends TestCase
+{
+    public function testSetConfigXMLParameters()
+    {
+        $params             = $this->generateSetConfigXMLParams();
+        $setConfigXMLParams = $this->getSetConfigXMLMock($params);
+
+        $this->assertEquals($params['meetingId'], $setConfigXMLParams->getMeetingId());
+
+        // Test setters that are ignored by the constructor
+        $setConfigXMLParams->setMeetingId($newId = $this->faker->uuid);
+        $this->assertEquals($newId, $setConfigXMLParams->getMeetingId());
+    }
+}

--- a/tests/Responses/SetConfigXMLResponseTest.php
+++ b/tests/Responses/SetConfigXMLResponseTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Parameters;
+
+use BigBlueButton\Responses\SetConfigXMLResponse;
+use BigBlueButton\TestCase;
+
+class SetConfigXMLResponseTest extends TestCase
+{
+    /**
+     * @var \BigBlueButton\Responses\SetConfigXMLResponse
+     */
+    private $protect;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $xml = $this->loadXmlFile(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'set_config_xml.xml');
+
+        $this->config = new SetConfigXMLResponse($xml);
+    }
+
+    public function testSetConfigXMLResponseContent()
+    {
+        $this->assertEquals('SUCCESS', $this->config->getReturnCode());
+        $this->assertEquals('TETDApIC', $this->config->getToken());
+    }
+
+    public function testSetConfigXMLResponseTypes()
+    {
+        $this->assertEachGetterValueIsString($this->config, ['getReturnCode']);
+        $this->assertEachGetterValueIsString($this->config, ['getToken']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,7 +56,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function createRealMeeting($bbb)
     {
         $createMeetingParams = $this->generateCreateParams();
-        $createMeetingMock   = $this->getCreateParamsMock($createMeetingParams);
+        $createMeetingMock   = $this->getCreateMock($createMeetingParams);
 
         return $bbb->createMeeting($createMeetingMock);
     }
@@ -91,7 +91,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
      *
      * @return CreateMeetingParameters
      */
-    protected function getCreateParamsMock($params)
+    protected function getCreateMock($params)
     {
         $createMeetingParams = new CreateMeetingParameters($params['meetingId'], $params['meetingName']);
         $createMeetingParams->setAttendeePassword($params['attendeePassword'])->setModeratorPassword($params['moderatorPassword'])->

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,7 @@ namespace BigBlueButton;
 use BigBlueButton\Parameters\CreateMeetingParameters as CreateMeetingParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
 use BigBlueButton\Parameters\JoinMeetingParameters as JoinMeetingParameters;
+use BigBlueButton\Parameters\SetConfigXMLParameters as SetConfigXMLParameters;
 use BigBlueButton\Parameters\UpdateRecordingsParameters as UpdateRecordingsParameters;
 use BigBlueButton\Responses\CreateMeetingResponse;
 use BigBlueButton\Responses\UpdateRecordingsResponse;
@@ -181,6 +182,28 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $updateRecordingsParams->addMeta('presenter', $params['meta_presenter']);
 
         return $updateRecordingsParams;
+    }
+
+    /**
+     * @return array
+     */
+    protected function generateSetConfigXMLParams()
+    {
+        return [
+            'meetingId'               => $this->faker->uuid,
+        ];
+    }
+
+    /**
+     * @param $params array
+     *
+     * @return SetConfigXMLParameters
+     */
+    protected function getSetConfigXMLMock($params)
+    {
+        $setConfigXMLParams = new SetConfigXMLParameters($params['meetingId']);
+
+        return $setConfigXMLParams;
     }
 
     // Load fixtures

--- a/tests/fixtures/set_config_xml.xml
+++ b/tests/fixtures/set_config_xml.xml
@@ -1,0 +1,4 @@
+<response>
+    <returncode>SUCCESS</returncode>
+    <token>TETDApIC</token>
+</response>


### PR DESCRIPTION
Implementation of updateRecordings for updating the metaParameters in a recording.

http://docs.bigbluebutton.org/dev/api.html#setconfigxml

This PR also includes a fix to the processXmlResponse method that was preventing request to be executed as GET. The reality is that only create and setConfigXML require POST requests.