### PR TITLE
Added support for lock settings when creating meetings

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -121,32 +121,32 @@ class CreateMeetingParameters extends MetaParameters
     /**
      * @var bool
      */
-    private $lockSettingsDisableCam = true;
+    private $lockSettingsDisableCam;
 
     /**
      * @var bool
      */
-    private $lockSettingsDisableMic = true;
+    private $lockSettingsDisableMic;
 
     /**
      * @var bool
      */
-    private $lockSettingsDisablePrivateChat = true;
+    private $lockSettingsDisablePrivateChat;
 
     /**
      * @var bool
      */
-    private $lockSettingsDisablePublicChat = true;
+    private $lockSettingsDisablePublicChat;
 
     /**
      * @var bool
      */
-    private $lockSettingsDisableNote = true;
+    private $lockSettingsDisableNote;
 
     /**
      * @var bool
      */
-    private $lockSettingsLockedLayout = true;
+    private $lockSettingsLockedLayout;
 
     /**
      * @var bool

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -143,18 +143,28 @@ class CreateMeetingParameters extends MetaParameters
      */
     private $lockSettingsDisableNote;
 
-    /**
-     * @var bool
+	/**
+	 * @var bool
+	 */
+	private $lockSettingsHideUserList;
+
+	/**
+	 * @var bool
      */
     private $lockSettingsLockedLayout;
 
     /**
      * @var bool
      */
-    private $lockSettingsLockedOnJoin = true;
+    private $lockSettingsLockOnJoin = true;
 
-    /**
-     * @var array
+	/**
+	 * @var bool
+	 */
+	private $lockSettingsLockOnJoinConfigurable;
+
+	/**
+	 * @var array
      */
     private $presentations = [];
 
@@ -661,10 +671,29 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isLockSettingsLockedLayout()
+	/**
+	 * @return bool
+	 */
+	public function isLockSettingsHideUserList()
+	{
+		return $this->lockSettingsHideUserList;
+	}
+
+	/**
+	 * @param  bool                    $lockSettingsHideUserList
+	 * @return CreateMeetingParameters
+	 */
+	public function setLockSettingsHideUserList($lockSettingsHideUserList)
+	{
+		$this->lockSettingsHideUserList = $lockSettingsHideUserList;
+
+		return $this;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isLockSettingsLockedLayout()
     {
         return $this->lockSettingsLockedLayout;
     }
@@ -683,25 +712,44 @@ class CreateMeetingParameters extends MetaParameters
     /**
      * @return bool
      */
-    public function isLockSettingsLockedOnJoin()
+    public function isLockSettingsLockOnJoin()
     {
-        return $this->lockSettingsLockedOnJoin;
+        return $this->lockSettingsLockOnJoin;
     }
 
     /**
-     * @param  bool                    $lockedOnJoin
+     * @param  bool                    $lockOnJoin
      * @return CreateMeetingParameters
      */
-    public function setLockSettingsLockedOnJoin($lockedOnJoin)
+    public function setLockSettingsLockOnJoin($lockOnJoin)
     {
-        $this->lockedOnJoin = $lockedOnJoin;
+        $this->lockSettingsLockOnJoin = $lockOnJoin;
 
         return $this;
     }
 
-    /**
-     * @param $endCallbackUrl
-     * @return CreateMeetingParameters
+	/**
+	 * @return bool
+	 */
+	public function isLockSettingsLockOnJoinConfigurable()
+	{
+		return $this->lockSettingsLockOnJoinConfigurable;
+	}
+
+	/**
+	 * @param  bool                    $lockOnJoinConfigurable
+	 * @return CreateMeetingParameters
+	 */
+	public function setLockSettingsLockOnJoinConfigurable($lockOnJoinConfigurable)
+	{
+		$this->lockSettingsLockOnJoinConfigurable = $lockOnJoinConfigurable;
+
+		return $this;
+	}
+
+	/**
+	 * @param $endCallbackUrl
+	 * @return CreateMeetingParameters
      */
     public function setEndCallbackUrl($endCallbackUrl)
     {
@@ -874,7 +922,7 @@ class CreateMeetingParameters extends MetaParameters
             'lockSettingsDisablePublicChat'  => $this->isLockSettingsDisablePublicChat() ? 'true' : 'false',
             'lockSettingsDisableNote'        => $this->isLockSettingsDisableNote() ? 'true' : 'false',
             'lockSettingsLockedLayout'       => $this->isLockSettingsLockedLayout() ? 'true' : 'false',
-            'lockSettingsLockOnJoin'         => $this->isLockSettingsLockedOnJoin() ? 'true' : 'false',
+            'lockSettingsLockOnJoin'         => $this->isLockSettingsLockOnJoin() ? 'true' : 'false',
         ];
 
         // Add breakout rooms parameters only if the meeting is a breakout room

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -143,13 +143,13 @@ class CreateMeetingParameters extends MetaParameters
      */
     private $lockSettingsDisableNote;
 
-	/**
-	 * @var bool
-	 */
-	private $lockSettingsHideUserList;
+    /**
+     * @var bool
+     */
+    private $lockSettingsHideUserList;
 
-	/**
-	 * @var bool
+    /**
+     * @var bool
      */
     private $lockSettingsLockedLayout;
 
@@ -158,13 +158,13 @@ class CreateMeetingParameters extends MetaParameters
      */
     private $lockSettingsLockOnJoin = true;
 
-	/**
-	 * @var bool
-	 */
-	private $lockSettingsLockOnJoinConfigurable;
+    /**
+     * @var bool
+     */
+    private $lockSettingsLockOnJoinConfigurable;
 
-	/**
-	 * @var array
+    /**
+     * @var array
      */
     private $presentations = [];
 
@@ -671,29 +671,29 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-	/**
-	 * @return bool
-	 */
-	public function isLockSettingsHideUserList()
-	{
-		return $this->lockSettingsHideUserList;
-	}
+    /**
+     * @return bool
+     */
+    public function isLockSettingsHideUserList()
+    {
+        return $this->lockSettingsHideUserList;
+    }
 
-	/**
-	 * @param  bool                    $lockSettingsHideUserList
-	 * @return CreateMeetingParameters
-	 */
-	public function setLockSettingsHideUserList($lockSettingsHideUserList)
-	{
-		$this->lockSettingsHideUserList = $lockSettingsHideUserList;
+    /**
+     * @param  bool                    $lockSettingsHideUserList
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsHideUserList($lockSettingsHideUserList)
+    {
+        $this->lockSettingsHideUserList = $lockSettingsHideUserList;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * @return bool
-	 */
-	public function isLockSettingsLockedLayout()
+    /**
+     * @return bool
+     */
+    public function isLockSettingsLockedLayout()
     {
         return $this->lockSettingsLockedLayout;
     }
@@ -728,28 +728,28 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-	/**
-	 * @return bool
-	 */
-	public function isLockSettingsLockOnJoinConfigurable()
-	{
-		return $this->lockSettingsLockOnJoinConfigurable;
-	}
+    /**
+     * @return bool
+     */
+    public function isLockSettingsLockOnJoinConfigurable()
+    {
+        return $this->lockSettingsLockOnJoinConfigurable;
+    }
 
-	/**
-	 * @param  bool                    $lockOnJoinConfigurable
-	 * @return CreateMeetingParameters
-	 */
-	public function setLockSettingsLockOnJoinConfigurable($lockOnJoinConfigurable)
-	{
-		$this->lockSettingsLockOnJoinConfigurable = $lockOnJoinConfigurable;
+    /**
+     * @param  bool                    $lockOnJoinConfigurable
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsLockOnJoinConfigurable($lockOnJoinConfigurable)
+    {
+        $this->lockSettingsLockOnJoinConfigurable = $lockOnJoinConfigurable;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * @param $endCallbackUrl
-	 * @return CreateMeetingParameters
+    /**
+     * @param $endCallbackUrl
+     * @return CreateMeetingParameters
      */
     public function setEndCallbackUrl($endCallbackUrl)
     {

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -119,6 +119,41 @@ class CreateMeetingParameters extends MetaParameters
     private $muteOnStart;
 
     /**
+     * @var bool
+     */
+    private $lockSettingsDisableCam = true;
+
+    /**
+     * @var bool
+     */
+    private $lockSettingsDisableMic = true;
+
+    /**
+     * @var bool
+     */
+    private $lockSettingsDisablePrivateChat = true;
+
+    /**
+     * @var bool
+     */
+    private $lockSettingsDisablePublicChat = true;
+
+    /**
+     * @var bool
+     */
+    private $lockSettingsDisableNote = true;
+
+    /**
+     * @var bool
+     */
+    private $lockSettingsLockedLayout = true;
+
+    /**
+     * @var bool
+     */
+    private $lockSettingsLockedOnJoin = true;
+
+    /**
      * @var array
      */
     private $presentations = [];
@@ -532,6 +567,139 @@ class CreateMeetingParameters extends MetaParameters
     }
 
     /**
+     * @return bool
+     */
+    public function isLockSettingsDisableCam()
+    {
+        return $this->lockSettingsDisableCam;
+    }
+
+    /**
+     * @param  bool                    $lockSettingsDisableCam
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsDisableCam($lockSettingsDisableCam)
+    {
+        $this->lockSettingsDisableCam = $lockSettingsDisableCam;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLockSettingsDisableMic()
+    {
+        return $this->lockSettingsDisableMic;
+    }
+
+    /**
+     * @param  bool                    $lockSettingsDisableMic
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsDisableMic($lockSettingsDisableMic)
+    {
+        $this->lockSettingsDisableMic = $lockSettingsDisableMic;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLockSettingsDisablePrivateChat()
+    {
+        return $this->lockSettingsDisablePrivateChat;
+    }
+
+    /**
+     * @param  bool                    $lockSettingsDisablePrivateChat
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsDisablePrivateChat($lockSettingsDisablePrivateChat)
+    {
+        $this->lockSettingsDisablePrivateChat = $lockSettingsDisablePrivateChat;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLockSettingsDisablePublicChat()
+    {
+        return $this->lockSettingsDisablePublicChat;
+    }
+
+    /**
+     * @param  bool                    $lockSettingsDisablePublicChat
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsDisablePublicChat($lockSettingsDisablePublicChat)
+    {
+        $this->lockSettingsDisablePublicChat = $lockSettingsDisablePublicChat;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLockSettingsDisableNote()
+    {
+        return $this->lockSettingsDisableNote;
+    }
+
+    /**
+     * @param  bool                    $lockSettingsDisableNote
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsDisableNote($lockSettingsDisableNote)
+    {
+        $this->lockSettingsDisableNote = $lockSettingsDisableNote;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLockSettingsLockedLayout()
+    {
+        return $this->lockSettingsLockedLayout;
+    }
+
+    /**
+     * @param  bool                    $lockSettingsLockedLayout
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsLockedLayout($lockSettingsLockedLayout)
+    {
+        $this->lockSettingsLockedLayout = $lockSettingsLockedLayout;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLockSettingsLockedOnJoin()
+    {
+        return $this->lockSettingsLockedOnJoin;
+    }
+
+    /**
+     * @param  bool                    $lockedOnJoin
+     * @return CreateMeetingParameters
+     */
+    public function setLockSettingsLockedOnJoin($lockedOnJoin)
+    {
+        $this->lockedOnJoin = $lockedOnJoin;
+
+        return $this;
+    }
+
+    /**
      * @param $endCallbackUrl
      * @return CreateMeetingParameters
      */
@@ -681,25 +849,32 @@ class CreateMeetingParameters extends MetaParameters
     public function getHTTPQuery()
     {
         $queries = [
-            'name'                    => $this->meetingName,
-            'meetingID'               => $this->meetingId,
-            'attendeePW'              => $this->attendeePassword,
-            'moderatorPW'             => $this->moderatorPassword,
-            'dialNumber'              => $this->dialNumber,
-            'voiceBridge'             => $this->voiceBridge,
-            'webVoice'                => $this->webVoice,
-            'logoutURL'               => $this->logoutUrl,
-            'record'                  => $this->record ? 'true' : 'false',
-            'duration'                => $this->duration,
-            'maxParticipants'         => $this->maxParticipants,
-            'autoStartRecording'      => $this->autoStartRecording ? 'true' : 'false',
-            'allowStartStopRecording' => $this->allowStartStopRecording ? 'true' : 'false',
-            'welcome'                 => trim($this->welcomeMessage),
-            'moderatorOnlyMessage'    => trim($this->moderatorOnlyMessage),
-            'webcamsOnlyForModerator' => $this->webcamsOnlyForModerator ? 'true' : 'false',
-            'logo'                    => $this->logo,
-            'copyright'               => $this->copyright,
-            'muteOnStart'             => $this->muteOnStart,
+            'name'                           => $this->meetingName,
+            'meetingID'                      => $this->meetingId,
+            'attendeePW'                     => $this->attendeePassword,
+            'moderatorPW'                    => $this->moderatorPassword,
+            'dialNumber'                     => $this->dialNumber,
+            'voiceBridge'                    => $this->voiceBridge,
+            'webVoice'                       => $this->webVoice,
+            'logoutURL'                      => $this->logoutUrl,
+            'record'                         => $this->record ? 'true' : 'false',
+            'duration'                       => $this->duration,
+            'maxParticipants'                => $this->maxParticipants,
+            'autoStartRecording'             => $this->autoStartRecording ? 'true' : 'false',
+            'allowStartStopRecording'        => $this->allowStartStopRecording ? 'true' : 'false',
+            'welcome'                        => trim($this->welcomeMessage),
+            'moderatorOnlyMessage'           => trim($this->moderatorOnlyMessage),
+            'webcamsOnlyForModerator'        => $this->webcamsOnlyForModerator ? 'true' : 'false',
+            'logo'                           => $this->logo,
+            'copyright'                      => $this->copyright,
+            'muteOnStart'                    => $this->muteOnStart,
+            'lockSettingsDisableCam'         => $this->isLockSettingsDisableCam() ? 'true' : 'false',
+            'lockSettingsDisableMic'         => $this->isLockSettingsDisableMic() ? 'true' : 'false',
+            'lockSettingsDisablePrivateChat' => $this->isLockSettingsDisablePrivateChat() ? 'true' : 'false',
+            'lockSettingsDisablePublicChat'  => $this->isLockSettingsDisablePublicChat() ? 'true' : 'false',
+            'lockSettingsDisableNote'        => $this->isLockSettingsDisableNote() ? 'true' : 'false',
+            'lockSettingsLockedLayout'       => $this->isLockSettingsLockedLayout() ? 'true' : 'false',
+            'lockSettingsLockOnJoin'         => $this->isLockSettingsLockedOnJoin() ? 'true' : 'false',
         ];
 
         // Add breakout rooms parameters only if the meeting is a breakout room

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -50,6 +50,13 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['logo'], $createMeetingParams->getLogo());
         $this->assertEquals($params['copyright'], $createMeetingParams->getCopyright());
         $this->assertEquals($params['muteOnStart'], $createMeetingParams->isMuteOnStart());
+        $this->assertEquals($params['lockSettingsDisableCam'], $createMeetingParams->isLockSettingsDisableCam());
+        $this->assertEquals($params['lockSettingsDisableMic'], $createMeetingParams->isLockSettingsDisableMic());
+        $this->assertEquals($params['lockSettingsDisablePrivateChat'], $createMeetingParams->isLockSettingsDisablePrivateChat());
+        $this->assertEquals($params['lockSettingsDisablePublicChat'], $createMeetingParams->isLockSettingsDisablePublicChat());
+        $this->assertEquals($params['lockSettingsDisableNote'], $createMeetingParams->isLockSettingsDisableNote());
+        $this->assertEquals($params['lockSettingsLockedLayout'], $createMeetingParams->isLockSettingsLockedLayout());
+        $this->assertEquals($params['lockSettingsLockedOnJoin'], $createMeetingParams->isLockSettingsLockedOnJoin());
         $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
         $this->assertEquals($params['meta_endCallbackUrl'], $createMeetingParams->getMeta('endCallbackUrl'));
 

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -55,9 +55,11 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['lockSettingsDisablePrivateChat'], $createMeetingParams->isLockSettingsDisablePrivateChat());
         $this->assertEquals($params['lockSettingsDisablePublicChat'], $createMeetingParams->isLockSettingsDisablePublicChat());
         $this->assertEquals($params['lockSettingsDisableNote'], $createMeetingParams->isLockSettingsDisableNote());
-        $this->assertEquals($params['lockSettingsLockedLayout'], $createMeetingParams->isLockSettingsLockedLayout());
-        $this->assertEquals($params['lockSettingsLockedOnJoin'], $createMeetingParams->isLockSettingsLockedOnJoin());
-        $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
+	    $this->assertEquals($params['lockSettingsHideUserList'], $createMeetingParams->isLockSettingsHideUserList());
+	    $this->assertEquals($params['lockSettingsLockedLayout'], $createMeetingParams->isLockSettingsLockedLayout());
+        $this->assertEquals($params['lockSettingsLockOnJoin'], $createMeetingParams->isLockSettingsLockOnJoin());
+	    $this->assertEquals($params['lockSettingsLockOnJoinConfigurable'], $createMeetingParams->isLockSettingsLockOnJoinConfigurable());
+	    $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
         $this->assertEquals($params['meta_endCallbackUrl'], $createMeetingParams->getMeta('endCallbackUrl'));
 
         // Check values are empty of this is not a breakout room

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -55,11 +55,11 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['lockSettingsDisablePrivateChat'], $createMeetingParams->isLockSettingsDisablePrivateChat());
         $this->assertEquals($params['lockSettingsDisablePublicChat'], $createMeetingParams->isLockSettingsDisablePublicChat());
         $this->assertEquals($params['lockSettingsDisableNote'], $createMeetingParams->isLockSettingsDisableNote());
-	    $this->assertEquals($params['lockSettingsHideUserList'], $createMeetingParams->isLockSettingsHideUserList());
-	    $this->assertEquals($params['lockSettingsLockedLayout'], $createMeetingParams->isLockSettingsLockedLayout());
+        $this->assertEquals($params['lockSettingsHideUserList'], $createMeetingParams->isLockSettingsHideUserList());
+        $this->assertEquals($params['lockSettingsLockedLayout'], $createMeetingParams->isLockSettingsLockedLayout());
         $this->assertEquals($params['lockSettingsLockOnJoin'], $createMeetingParams->isLockSettingsLockOnJoin());
-	    $this->assertEquals($params['lockSettingsLockOnJoinConfigurable'], $createMeetingParams->isLockSettingsLockOnJoinConfigurable());
-	    $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
+        $this->assertEquals($params['lockSettingsLockOnJoinConfigurable'], $createMeetingParams->isLockSettingsLockOnJoinConfigurable());
+        $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
         $this->assertEquals($params['meta_endCallbackUrl'], $createMeetingParams->getMeta('endCallbackUrl'));
 
         // Check values are empty of this is not a breakout room

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,27 +67,34 @@ class TestCase extends \PHPUnit\Framework\TestCase
     protected function generateCreateParams()
     {
         return [
-            'meetingName'             => $this->faker->name,
-            'meetingId'               => $this->faker->uuid,
-            'attendeePassword'        => $this->faker->password,
-            'moderatorPassword'       => $this->faker->password,
-            'autoStartRecording'      => $this->faker->boolean(50),
-            'dialNumber'              => $this->faker->phoneNumber,
-            'voiceBridge'             => $this->faker->randomNumber(5),
-            'webVoice'                => $this->faker->word,
-            'logoutUrl'               => $this->faker->url,
-            'maxParticipants'         => $this->faker->numberBetween(2, 100),
-            'record'                  => $this->faker->boolean(50),
-            'duration'                => $this->faker->numberBetween(0, 6000),
-            'welcomeMessage'          => $this->faker->sentence,
-            'allowStartStopRecording' => $this->faker->boolean(50),
-            'moderatorOnlyMessage'    => $this->faker->sentence,
-            'webcamsOnlyForModerator' => $this->faker->boolean(50),
-            'logo'                    => $this->faker->imageUrl(330, 70),
-            'copyright'               => $this->faker->text,
-            'muteOnStart'             => $this->faker->boolean(50),
-            'meta_presenter'          => $this->faker->name,
-            'meta_endCallbackUrl'     => $this->faker->url
+            'meetingName'                    => $this->faker->name,
+            'meetingId'                      => $this->faker->uuid,
+            'attendeePassword'               => $this->faker->password,
+            'moderatorPassword'              => $this->faker->password,
+            'autoStartRecording'             => $this->faker->boolean(50),
+            'dialNumber'                     => $this->faker->phoneNumber,
+            'voiceBridge'                    => $this->faker->randomNumber(5),
+            'webVoice'                       => $this->faker->word,
+            'logoutUrl'                      => $this->faker->url,
+            'maxParticipants'                => $this->faker->numberBetween(2, 100),
+            'record'                         => $this->faker->boolean(50),
+            'duration'                       => $this->faker->numberBetween(0, 6000),
+            'welcomeMessage'                 => $this->faker->sentence,
+            'allowStartStopRecording'        => $this->faker->boolean(50),
+            'moderatorOnlyMessage'           => $this->faker->sentence,
+            'webcamsOnlyForModerator'        => $this->faker->boolean(50),
+            'logo'                           => $this->faker->imageUrl(330, 70),
+            'copyright'                      => $this->faker->text,
+            'muteOnStart'                    => $this->faker->boolean(50),
+            'lockSettingsDisableCam'         => $this->faker->boolean(50),
+            'lockSettingsDisableMic'         => $this->faker->boolean(50),
+            'lockSettingsDisablePrivateChat' => $this->faker->boolean(50),
+            'lockSettingsDisablePublicChat'  => $this->faker->boolean(50),
+            'lockSettingsDisableNote'        => $this->faker->boolean(50),
+            'lockSettingsLockedLayout'       => $this->faker->boolean(50),
+            'lockSettingsLockedOnJoin'       => $this->faker->boolean(50),
+            'meta_presenter'                 => $this->faker->name,
+            'meta_endCallbackUrl'            => $this->faker->url
         ];
     }
 
@@ -120,7 +127,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
             ->setDuration($params['duration'])->setWelcomeMessage($params['welcomeMessage'])->setAutoStartRecording($params['autoStartRecording'])
             ->setAllowStartStopRecording($params['allowStartStopRecording'])->setModeratorOnlyMessage($params['moderatorOnlyMessage'])
             ->setWebcamsOnlyForModerator($params['webcamsOnlyForModerator'])->setLogo($params['logo'])->setCopyright($params['copyright'])
-            ->setEndCallbackUrl($params['meta_endCallbackUrl'])->setMuteOnStart($params['muteOnStart'])->addMeta('presenter', $params['meta_presenter']);
+            ->setEndCallbackUrl($params['meta_endCallbackUrl'])->setMuteOnStart($params['muteOnStart'])->setLockSettingsDisableCam($params['lockSettingsDisableCam'])
+	        ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
+	        ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
+	        ->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])->setLockSettingsLockedOnJoin($params['lockSettingsLockedOnJoin'])
+	        ->addMeta('presenter', $params['meta_presenter']);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,34 +67,36 @@ class TestCase extends \PHPUnit\Framework\TestCase
     protected function generateCreateParams()
     {
         return [
-            'meetingName'                    => $this->faker->name,
-            'meetingId'                      => $this->faker->uuid,
-            'attendeePassword'               => $this->faker->password,
-            'moderatorPassword'              => $this->faker->password,
-            'autoStartRecording'             => $this->faker->boolean(50),
-            'dialNumber'                     => $this->faker->phoneNumber,
-            'voiceBridge'                    => $this->faker->randomNumber(5),
-            'webVoice'                       => $this->faker->word,
-            'logoutUrl'                      => $this->faker->url,
-            'maxParticipants'                => $this->faker->numberBetween(2, 100),
-            'record'                         => $this->faker->boolean(50),
-            'duration'                       => $this->faker->numberBetween(0, 6000),
-            'welcomeMessage'                 => $this->faker->sentence,
-            'allowStartStopRecording'        => $this->faker->boolean(50),
-            'moderatorOnlyMessage'           => $this->faker->sentence,
-            'webcamsOnlyForModerator'        => $this->faker->boolean(50),
-            'logo'                           => $this->faker->imageUrl(330, 70),
-            'copyright'                      => $this->faker->text,
-            'muteOnStart'                    => $this->faker->boolean(50),
-            'lockSettingsDisableCam'         => $this->faker->boolean(50),
-            'lockSettingsDisableMic'         => $this->faker->boolean(50),
-            'lockSettingsDisablePrivateChat' => $this->faker->boolean(50),
-            'lockSettingsDisablePublicChat'  => $this->faker->boolean(50),
-            'lockSettingsDisableNote'        => $this->faker->boolean(50),
-            'lockSettingsLockedLayout'       => $this->faker->boolean(50),
-            'lockSettingsLockedOnJoin'       => $this->faker->boolean(50),
-            'meta_presenter'                 => $this->faker->name,
-            'meta_endCallbackUrl'            => $this->faker->url
+            'meetingName'                        => $this->faker->name,
+            'meetingId'                          => $this->faker->uuid,
+            'attendeePassword'                   => $this->faker->password,
+            'moderatorPassword'                  => $this->faker->password,
+            'autoStartRecording'                 => $this->faker->boolean(50),
+            'dialNumber'                         => $this->faker->phoneNumber,
+            'voiceBridge'                        => $this->faker->randomNumber(5),
+            'webVoice'                           => $this->faker->word,
+            'logoutUrl'                          => $this->faker->url,
+            'maxParticipants'                    => $this->faker->numberBetween(2, 100),
+            'record'                             => $this->faker->boolean(50),
+            'duration'                           => $this->faker->numberBetween(0, 6000),
+            'welcomeMessage'                     => $this->faker->sentence,
+            'allowStartStopRecording'            => $this->faker->boolean(50),
+            'moderatorOnlyMessage'               => $this->faker->sentence,
+            'webcamsOnlyForModerator'            => $this->faker->boolean(50),
+            'logo'                               => $this->faker->imageUrl(330, 70),
+            'copyright'                          => $this->faker->text,
+            'muteOnStart'                        => $this->faker->boolean(50),
+            'lockSettingsDisableCam'             => $this->faker->boolean(50),
+            'lockSettingsDisableMic'             => $this->faker->boolean(50),
+            'lockSettingsDisablePrivateChat'     => $this->faker->boolean(50),
+            'lockSettingsDisablePublicChat'      => $this->faker->boolean(50),
+            'lockSettingsDisableNote'            => $this->faker->boolean(50),
+	        'lockSettingsHideUserList'           => $this->faker->boolean(50),
+	        'lockSettingsLockedLayout'           => $this->faker->boolean(50),
+            'lockSettingsLockOnJoin'             => $this->faker->boolean(50),
+	        'lockSettingsLockOnJoinConfigurable' => $this->faker->boolean(50),
+	        'meta_presenter'                     => $this->faker->name,
+            'meta_endCallbackUrl'                => $this->faker->url
         ];
     }
 
@@ -130,7 +132,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
             ->setEndCallbackUrl($params['meta_endCallbackUrl'])->setMuteOnStart($params['muteOnStart'])->setLockSettingsDisableCam($params['lockSettingsDisableCam'])
 	        ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
 	        ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
-	        ->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])->setLockSettingsLockedOnJoin($params['lockSettingsLockedOnJoin'])
+	        ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
+	        ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])->setLockSettingsLockOnJoinConfigurable($params['lockSettingsLockOnJoin'])
 	        ->addMeta('presenter', $params['meta_presenter']);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -91,11 +91,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
             'lockSettingsDisablePrivateChat'     => $this->faker->boolean(50),
             'lockSettingsDisablePublicChat'      => $this->faker->boolean(50),
             'lockSettingsDisableNote'            => $this->faker->boolean(50),
-	        'lockSettingsHideUserList'              => $this->faker->boolean(50),
-	        'lockSettingsLockedLayout'              => $this->faker->boolean(50),
+            'lockSettingsHideUserList'           => $this->faker->boolean(50),
+            'lockSettingsLockedLayout'           => $this->faker->boolean(50),
             'lockSettingsLockOnJoin'             => $this->faker->boolean(50),
-	        'lockSettingsLockOnJoinConfigurable'    => $this->faker->boolean(50),
-	        'meta_presenter'                        => $this->faker->name,
+            'lockSettingsLockOnJoinConfigurable' => $this->faker->boolean(50),
+            'meta_presenter'                     => $this->faker->name,
             'meta_endCallbackUrl'                => $this->faker->url
         ];
     }
@@ -130,11 +130,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
             ->setAllowStartStopRecording($params['allowStartStopRecording'])->setModeratorOnlyMessage($params['moderatorOnlyMessage'])
             ->setWebcamsOnlyForModerator($params['webcamsOnlyForModerator'])->setLogo($params['logo'])->setCopyright($params['copyright'])
             ->setEndCallbackUrl($params['meta_endCallbackUrl'])->setMuteOnStart($params['muteOnStart'])->setLockSettingsDisableCam($params['lockSettingsDisableCam'])
-	        ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
-	        ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
-	        ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
-	        ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])->setLockSettingsLockOnJoinConfigurable($params['lockSettingsLockOnJoin'])
-	        ->addMeta('presenter', $params['meta_presenter']);
+            ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
+            ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
+            ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
+            ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])->setLockSettingsLockOnJoinConfigurable($params['lockSettingsLockOnJoin'])
+            ->addMeta('presenter', $params['meta_presenter']);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -91,11 +91,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
             'lockSettingsDisablePrivateChat'     => $this->faker->boolean(50),
             'lockSettingsDisablePublicChat'      => $this->faker->boolean(50),
             'lockSettingsDisableNote'            => $this->faker->boolean(50),
-	        'lockSettingsHideUserList'           => $this->faker->boolean(50),
-	        'lockSettingsLockedLayout'           => $this->faker->boolean(50),
+	        'lockSettingsHideUserList'              => $this->faker->boolean(50),
+	        'lockSettingsLockedLayout'              => $this->faker->boolean(50),
             'lockSettingsLockOnJoin'             => $this->faker->boolean(50),
-	        'lockSettingsLockOnJoinConfigurable' => $this->faker->boolean(50),
-	        'meta_presenter'                     => $this->faker->name,
+	        'lockSettingsLockOnJoinConfigurable'    => $this->faker->boolean(50),
+	        'meta_presenter'                        => $this->faker->name,
             'meta_endCallbackUrl'                => $this->faker->url
         ];
     }


### PR DESCRIPTION
We needed the ability to set lock settings in our application, so we implemented #41 in a naive, straightforward fashion. We opted to use the long config names here instead of abbreviating them, but maybe it's better to strip the `lockSettings`-prefix from the method names for readability.