### PR TITLE
remove urlencode()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 /vendor/
 composer.lock
+.DS_Store
 
 ## Directory-based project format:
 .idea/

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -461,6 +461,7 @@ class BigBlueButton
             curl_setopt($ch, CURLOPT_ENCODING, 'UTF-8');
             curl_setopt($ch, CURLOPT_URL, $url);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
             curl_setopt($ch, CURLOPT_COOKIEFILE, $cookiefilepath);
             curl_setopt($ch, CURLOPT_COOKIEJAR, $cookiefilepath);

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -753,7 +753,7 @@ class CreateMeetingParameters extends MetaParameters
      */
     public function setEndCallbackUrl($endCallbackUrl)
     {
-        $this->addMeta('endCallbackUrl', urlencode($endCallbackUrl));
+        $this->addMeta('endCallbackUrl', $endCallbackUrl);
 
         return $this;
     }
@@ -764,7 +764,7 @@ class CreateMeetingParameters extends MetaParameters
      */
     public function setRecordingReadyCallbackUrl($recordingReadyCallbackUrl)
     {
-        $this->addMeta('bbb-recording-ready-url', urlencode($recordingReadyCallbackUrl));
+        $this->addMeta('bbb-recording-ready-url', $recordingReadyCallbackUrl);
 
         return $this;
     }

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -60,8 +60,8 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['lockSettingsLockOnJoin'], $createMeetingParams->isLockSettingsLockOnJoin());
         $this->assertEquals($params['lockSettingsLockOnJoinConfigurable'], $createMeetingParams->isLockSettingsLockOnJoinConfigurable());
         $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
-        $this->assertEquals($params['meta_endCallbackUrl'], urlencode($createMeetingParams->getMeta('endCallbackUrl')));
-        $this->assertEquals($params['meta_bbb-recording-ready-url'], urlencode($createMeetingParams->getMeta('bbb-recording-ready-url')));
+        $this->assertEquals($params['meta_endCallbackUrl'], $createMeetingParams->getMeta('endCallbackUrl'));
+        $this->assertEquals($params['meta_bbb-recording-ready-url'], $createMeetingParams->getMeta('bbb-recording-ready-url'));
 
         // Check values are empty of this is not a breakout room
         $this->assertNull($createMeetingParams->isBreakout());


### PR DESCRIPTION
As we are using `http_build_query` to URL-encoded so don't need extra `urlencode()`. This will resolve this issue: https://github.com/bigbluebutton/bigbluebutton/issues/8727 . It was my mistake on last pull request :( 