### PR TITLE
Add guestPolicy meetingParameter to control access on meeting

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -23,6 +23,10 @@ namespace BigBlueButton\Parameters;
  */
 class CreateMeetingParameters extends MetaParameters
 {
+    const ALWAYS_ACCEPT = 'ALWAYS_ACCEPT';
+    const ALWAYS_DENY   = 'ALWAYS_DENY';
+    const ASK_MODERATOR = 'ASK_MODERATOR';
+
     /**
      * @var string
      */
@@ -187,6 +191,11 @@ class CreateMeetingParameters extends MetaParameters
      * @var boolean
      */
     private $freeJoin;
+
+    /**
+     * @var string
+     */
+    private $guestPolicy = self::ALWAYS_ACCEPT;
 
     /**
      * CreateMeetingParameters constructor.
@@ -757,7 +766,7 @@ class CreateMeetingParameters extends MetaParameters
 
         return $this;
     }
-    
+
     /**
      * @param $recordingReadyCallbackUrl
      * @return CreateMeetingParameters
@@ -840,9 +849,62 @@ class CreateMeetingParameters extends MetaParameters
      */
     public function setFreeJoin($freeJoin)
     {
-        $this->freeJoin = $freeJoin;
+        $this->freeJoin    = $freeJoin;
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBlockedJoin()
+    {
+        return $this->guestPolicy === self::ALWAYS_DENY;
+    }
+
+    public function setBlockedJoin()
+    {
+        $this->guestPolicy = self::ALWAYS_DENY;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isModerateJoin()
+    {
+        return $this->guestPolicy === self::ASK_MODERATOR;
+    }
+
+    public function setModerateJoin()
+    {
+        $this->guestPolicy = self::ASK_MODERATOR;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOpenJoin()
+    {
+        return $this->guestPolicy === self::ALWAYS_ACCEPT;
+    }
+
+    public function setOpenJoin()
+    {
+        $this->guestPolicy = self::ALWAYS_ACCEPT;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGuestPolicy()
+    {
+        return $this->guestPolicy;
     }
 
     /**
@@ -927,6 +989,7 @@ class CreateMeetingParameters extends MetaParameters
             'logo'                               => $this->logo,
             'copyright'                          => $this->copyright,
             'muteOnStart'                        => $this->muteOnStart,
+            'guestPolicy'                        => $this->guestPolicy,
             'lockSettingsDisableCam'             => $this->isLockSettingsDisableCam() ? 'true' : 'false',
             'lockSettingsDisableMic'             => $this->isLockSettingsDisableMic() ? 'true' : 'false',
             'lockSettingsDisablePrivateChat'     => $this->isLockSettingsDisablePrivateChat() ? 'true' : 'false',

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -50,6 +50,7 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['logo'], $createMeetingParams->getLogo());
         $this->assertEquals($params['copyright'], $createMeetingParams->getCopyright());
         $this->assertEquals($params['muteOnStart'], $createMeetingParams->isMuteOnStart());
+        $this->assertEquals($params['guestPolicy'], $createMeetingParams->getGuestPolicy());
         $this->assertEquals($params['lockSettingsDisableCam'], $createMeetingParams->isLockSettingsDisableCam());
         $this->assertEquals($params['lockSettingsDisableMic'], $createMeetingParams->isLockSettingsDisableMic());
         $this->assertEquals($params['lockSettingsDisablePrivateChat'], $createMeetingParams->isLockSettingsDisablePrivateChat());
@@ -116,4 +117,5 @@ class CreateMeetingParametersTest extends TestCase
         $createMeetingParams->addPresentation('bbb_logo.png', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'bbb_logo.png'));
         $this->assertXmlStringEqualsXmlFile(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'presentation_with_embedded_file.xml', $createMeetingParams->getPresentationsAsXML());
     }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -85,6 +85,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
             'webcamsOnlyForModerator'            => $this->faker->boolean(50),
             'logo'                               => $this->faker->imageUrl(330, 70),
             'copyright'                          => $this->faker->text,
+            'guestPolicy'                        => 'ALWAYS_ACCEPT',
             'muteOnStart'                        => $this->faker->boolean(50),
             'lockSettingsDisableCam'             => $this->faker->boolean(50),
             'lockSettingsDisableMic'             => $this->faker->boolean(50),


### PR DESCRIPTION
Hi all,

This PR is to fix and upgrade the #65. 

Changes:

1. Add methods to make "guestPolicy" transparent to developers because values are restricted by BBB software.

2. Fix defined constant errors. 

See https://github.com/bigbluebutton/bigbluebutton-api-php/pull/65/files#diff-d008ae52434bbdb2f0ef792c25501bc3R26-R28

3. Keep setFreeJoin logic to keep BC. FreeJoin param is used on breakoutMeeting and it doesn't accept string values. 

4. Add test for guestPolicy with the default value

Thanks!