### PR TITLE
Fix test BigBlueButton\BigBlueButtonTest::testCreateMeetingUrl

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -124,18 +124,36 @@ class TestCase extends \PHPUnit\Framework\TestCase
     {
         $createMeetingParams = new CreateMeetingParameters($params['meetingId'], $params['meetingName']);
 
-        return $createMeetingParams->setAttendeePassword($params['attendeePassword'])->setModeratorPassword($params['moderatorPassword'])
-            ->setDialNumber($params['dialNumber'])->setVoiceBridge($params['voiceBridge'])->setWebVoice($params['webVoice'])
-            ->setLogoutUrl($params['logoutUrl'])->setMaxParticipants($params['maxParticipants'])->setRecord($params['record'])
-            ->setDuration($params['duration'])->setWelcomeMessage($params['welcomeMessage'])->setAutoStartRecording($params['autoStartRecording'])
-            ->setAllowStartStopRecording($params['allowStartStopRecording'])->setModeratorOnlyMessage($params['moderatorOnlyMessage'])
-            ->setWebcamsOnlyForModerator($params['webcamsOnlyForModerator'])->setLogo($params['logo'])->setCopyright($params['copyright'])
-            ->setEndCallbackUrl($params['meta_endCallbackUrl'])->setMuteOnStart($params['muteOnStart'])->setLockSettingsDisableCam($params['lockSettingsDisableCam'])
-            ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
-            ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
-            ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
-            ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])->setLockSettingsLockOnJoinConfigurable($params['lockSettingsLockOnJoin'])
-            ->addMeta('presenter', $params['meta_presenter']);
+        return $createMeetingParams
+            ->setAttendeePassword($params['attendeePassword'])
+            ->setModeratorPassword($params['moderatorPassword'])
+            ->setDialNumber($params['dialNumber'])
+            ->setVoiceBridge($params['voiceBridge'])
+            ->setWebVoice($params['webVoice'])
+            ->setLogoutUrl($params['logoutUrl'])
+            ->setMaxParticipants($params['maxParticipants'])
+            ->setRecord($params['record'])
+            ->setDuration($params['duration'])
+            ->setWelcomeMessage($params['welcomeMessage'])
+            ->setAutoStartRecording($params['autoStartRecording'])
+            ->setAllowStartStopRecording($params['allowStartStopRecording'])
+            ->setModeratorOnlyMessage($params['moderatorOnlyMessage'])
+            ->setWebcamsOnlyForModerator($params['webcamsOnlyForModerator'])
+            ->setLogo($params['logo'])
+            ->setCopyright($params['copyright'])
+            ->setEndCallbackUrl($params['meta_endCallbackUrl'])
+            ->setMuteOnStart($params['muteOnStart'])
+            ->setLockSettingsDisableCam($params['lockSettingsDisableCam'])
+            ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])
+            ->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
+            ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])
+            ->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
+            ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])
+            ->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
+            ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])
+            ->setLockSettingsLockOnJoinConfigurable($params['lockSettingsLockOnJoin'])
+            ->addMeta('presenter', $params['meta_presenter'])
+            ->addMeta('bbb-recording-ready-url', $params['meta_bbb-recording-ready-url']);
     }
 
     /**


### PR DESCRIPTION
Error messsage returned:

```
BigBlueButton\BigBlueButtonTest::testCreateMeetingUrl

Failed asserting that 'https://test-install.blindsidenetworks.com/bigbluebutton/api/create?name=Betty+Stehr&meetingID=e30b5632-37bd-3126-a922-946b113369ef&attendeePW=T1kF%7B7C_F&moderatorPW=t%7C%3BYZF%3Ar&dialNumber=%28289%29+814-5971+x8835&voiceBridge=28429&webVoice=repudiandae&logoutURL=http%3A%2F%2Fbahringer.com%2Fminus-magnam-assumenda-doloremque-non-vel-accusantium-consectetur-cumque&record=true&duration=600&maxParticipants=9&autoStartRecording=true&allowStartStopRecording=true&welcome=Dolores+minima+mollitia+laboriosam+quisquam.&moderatorOnlyMessage=Dignissimos+voluptatem+sed+sint+reprehenderit+eos+alias.&webcamsOnlyForModerator=false&logo=https%3A%2F%2Florempixel.com%2F330%2F70%2F%3F12862&copyright=Expedita+et+fugit+qui+assumenda+doloremque.+Rem+iusto+quibusdam+neque+illo+qui+voluptatem+voluptatem+dolore.+Quae+qui+non+rem+dicta.&lockSettingsDisableCam=true&lockSettingsDisableMic=false&lockSettingsDisablePrivateChat=true&lockSettingsDisablePublicChat=false&lockSettingsDisableNote=true&lockSettingsHideUserList=false&lockSettingsLockedLayout=true&lockSettingsLockOnJoin=true&lockSettingsLockOnJoinConfigurable=true&meta_endCallbackUrl=http%3A%2F%2Fwww.huel.org%2F&meta_presenter=Lily+Walter&checksum=023e44ba771f0cf007cbbbae36959f7769e4eca0' contains "=http%3A%2F%2Fwww.littel.info%2Ftemporibus-omnis-qui-cupiditate-laudantium".

/bigbluebutton-api-php/tests/BigBlueButtonTest.php:83
```

This PR is related to https://github.com/bigbluebutton/bigbluebutton-api-php/pull/68. On it new   "bbb-recording-ready-url" meta was added to fix error.