### PR TITLE
CreateMeetingParameters->getHTTPQuery tried to pass the muteOnStart a…

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -926,7 +926,7 @@ class CreateMeetingParameters extends MetaParameters
             'webcamsOnlyForModerator'            => $this->webcamsOnlyForModerator ? 'true' : 'false',
             'logo'                               => $this->logo,
             'copyright'                          => $this->copyright,
-            'muteOnStart'                        => $this->muteOnStart,
+            'muteOnStart'                        => $this->muteOnStart ? 'true' : 'false',
             'lockSettingsDisableCam'             => $this->isLockSettingsDisableCam() ? 'true' : 'false',
             'lockSettingsDisableMic'             => $this->isLockSettingsDisableMic() ? 'true' : 'false',
             'lockSettingsDisablePrivateChat'     => $this->isLockSettingsDisablePrivateChat() ? 'true' : 'false',


### PR DESCRIPTION
CreateMeetingParameters->getHTTPQuery tried to pass the muteOnStart as a PHP bool instead of a string resulting in the parameter never being usefully passed to BBB. (BBB expects 'true' and mute was not enabled when it got 1 instead.)