### PR TITLE
Fixed reading attendees (fixes #75)

### DIFF
--- a/src/Core/Attendee.php
+++ b/src/Core/Attendee.php
@@ -58,7 +58,7 @@ class Attendee
     /**
      * @var array
      */
-    private $customData;
+    private $customData = [];
 
     /**
      * @var string
@@ -80,8 +80,10 @@ class Attendee
         $this->hasVideo        = $xml->hasVideo->__toString() === 'true';
         $this->clientType      = $xml->clientType->__toString();
 
-        foreach ($xml->customdata->children() as $data) {
-            $this->customData[$data->getName()] = $data->__toString();
+        if ($xml->customData) {
+            foreach ($xml->customdata->children() as $data) {
+                $this->customData[$data->getName()] = $data->__toString();
+            }
         }
     }
 


### PR DESCRIPTION
Hi,

this PR is a proper fix to the issue @umutc describes in #75. I've just encountered this myself with our first steps using this lib.

Without the fix the API client will fail reading attendees via `getMeetingInfo` with "Node no longer exists"

Kind regards
Matthias