### PR TITLE
Handle bad responses

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -19,6 +19,7 @@
 namespace BigBlueButton;
 
 use BigBlueButton\Core\ApiMethod;
+use BigBlueButton\Exceptions\BadResponseException;
 use BigBlueButton\Parameters\CreateMeetingParameters;
 use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
@@ -478,6 +479,10 @@ class BigBlueButton
             $data = curl_exec($ch);
             if ($data === false) {
                 throw new \RuntimeException('Unhandled curl error: ' . curl_error($ch));
+            }
+            $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            if ($httpcode < 200 || $httpcode >= 300) {
+                throw new BadResponseException('Bad response, HTTP code: ' . $httpcode);
             }
             curl_close($ch);
 

--- a/src/Exceptions/BadResponseException.php
+++ b/src/Exceptions/BadResponseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BigBlueButton\Exceptions;
+
+use Exception;
+
+class BadResponseException extends Exception
+{
+}


### PR DESCRIPTION
In some cases a non 200 status is returned. This XML should not be processed as it might contain errors like:
```
<html>
<head><title>500 Internal Server Error</title></head>
<body bgcolor="white">
<center><h1>500 Internal Server Error</h1></center>
<hr><center>nginx/1.14.0 (Ubuntu)</center>
</body>
</html> 
```
Where the \<hr> is never closed and crashes SimpleXML:
```
String could not be parsed as XML in SimpleXMLElement->__construct() (line 495 of /var/www/html/vendor/bigbluebutton/bigbluebutton-api-php/src/BigBlueButton.php).
```

Another example:
```
<html>
<head><title>413 Request Entity Too Large</title></head>
<body bgcolor="white">
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.14.0 (Ubuntu)</center>
</body>
</html>
```
Which has the same issue. 