### PR TITLE
Update CreateMeetingParameters.php

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -890,7 +890,7 @@ class CreateMeetingParameters extends MetaParameters
      * @param  bool                    $guestPolicy
      * @return CreateMeetingParameters
      */
-    public function setFreeJoin($guestPolicy)
+    public function setGuestPolicy($guestPolicy)
     {
         $this->guestPolicy = $guestPolicy;
 


### PR DESCRIPTION
Fatal error: Cannot redeclare BigBlueButton\Parameters\CreateMeetingParameters::setFreeJoin