### PR TITLE
Allow the use of $urlBuilder for custom calls

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -58,8 +58,8 @@ class BigBlueButton
 {
     protected $securitySecret;
     protected $bbbServerBaseUrl;
-    protected $urlBuilder;
     protected $jSessionId;
+    public $urlBuilder;
 
     /**
      * BigBlueButton constructor.


### PR DESCRIPTION
Changing $urlBuilder from protected to public as this will help to build my custom BBB URL out of the box