### PR TITLE
Close Curl handle in php8

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -491,6 +491,7 @@ class BigBlueButton
                 throw new BadResponseException('Bad response, HTTP code: ' . $httpcode);
             }
             curl_close($ch);
+            unset($ch);
 
             $cookies = file_get_contents($cookiefilepath);
             if (strpos($cookies, 'JSESSIONID') !== false) {


### PR DESCRIPTION
Because Curl resources in php8 are objects, Curl handles are closed when the object is no longer referenced, or explicitly destroyed.
curl_close($ch) in php8 no longer has any effect.

Without closing the Curl handle, cookies are not saved to $cookiefilepath, and the jSessionId is always null.