### PR TITLE
Meeting creation fails with Update to Version 2.1

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -19,6 +19,8 @@
 
 namespace BigBlueButton\Parameters;
 
+use BigBlueButton\Core\MeetingLayout;
+
 /**
  * Class CreateMeetingParameters.
  */
@@ -173,7 +175,7 @@ class CreateMeetingParameters extends MetaParameters
     /**
      * @var bool
      */
-    private $allowModsToEjectCameras;
+    private $allowModsToEjectCameras = true;
 
     /**
      * @var array
@@ -243,27 +245,27 @@ class CreateMeetingParameters extends MetaParameters
     /**
      * @var boolean
      */
-    private $breakoutRoomsEnabled;
+    private $breakoutRoomsEnabled = true;
 
     /**
      * @var boolean
      */
-    private $breakoutRoomsRecord;
+    private $breakoutRoomsRecord = true;
 
     /**
      * @var boolean
      */
-    private $breakoutRoomsPrivateChatEnabled;
+    private $breakoutRoomsPrivateChatEnabled = true;
 
     /**
      * @var string
      */
-    private $meetingEndedURL;
+    private $meetingEndedURL = '';
 
     /**
      * @var string
      */
-    private $meetingLayout;
+    private $meetingLayout = MeetingLayout::SMART_LAYOUT;
 
     /**
      * CreateMeetingParameters constructor.


### PR DESCRIPTION
With version 2.1 (https://github.com/bigbluebutton/bigbluebutton-api-php/commit/5ceff705955706c97587001f8eb5c5ff874370f7) support for attributes of a newer BBB API Version were added. During the meeting creation I have encountered a problem.

At least the changes were introduced in a way, that would be a breaking change compared to version 2.0. The problem is that typed getter's are used in the `CreateMeetingParameters` for the new properties, but they have no type specific default. If one uses this class for meeting creation without explizit. setting them, it fails.

**Reproduce**
Just take the example for "meeting creation" from the wiki. Then one will get a fatal error

`
use BigBlueButton\BigBlueButton;
use BigBlueButton\Parameters\CreateMeetingParameters;

$bbb = new BigBlueButton();

$createMeetingParams = new CreateMeetingParameters(1, 'test');
$createMeetingParams->setAttendeePassword('abc');
$createMeetingParams->setModeratorPassword('abc');

$response = $bbb->createMeeting($createMeetingParams);
if ($response->getReturnCode() == 'FAILED') {
	return 'Can\'t create room! please contact our administrator.';
} else {
	// process after room created
}
`

**Workaround**

Add defaults for all the new parameters manually, like the following:
`
$createMeetingParams->setAllowModsToEjectCameras(true);
$createMeetingParams->setBreakoutRoomsEnabled(true);
$createMeetingParams->setBreakoutRoomsRecord(true);
$createMeetingParams->setBreakoutRoomsPrivateChatEnabled(true);
$createMeetingParams->setMeetingLayout(\BigBlueButton\Core\MeetingLayout::CUSTOM_LAYOUT);
`

**Solution**
We could add the defaults for the new parameters as defined in https://docs.bigbluebutton.org/dev/api.html#create in the parameter class.