### PR TITLE
remove guest parameter from query when guest was set to false

### DIFF
--- a/src/Parameters/JoinMeetingParameters.php
+++ b/src/Parameters/JoinMeetingParameters.php
@@ -442,7 +442,10 @@ class JoinMeetingParameters extends UserDataParameters
         foreach ($this->customParameters as $key => $value) {
             $queries[$key] = $value;
         }
-
+		
+      if(!$this->guest){
+		  unset($queries['guest']);
+	  }
         $this->buildUserData($queries);
 
         return $this->buildHTTPQuery($queries);


### PR DESCRIPTION
As you can see here in the docs , the guest parameter should not be sent as guest=false it should be guest = true otherwise we could not send the parameter .
https://docs.bigbluebutton.org/development/api/#join