### PR TITLE
feat: add new parameters to CreateMeetingParameters for BBB 2.6.9

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -320,6 +320,16 @@ class CreateMeetingParameters extends MetaParameters
     /**
      * @var array
      */
+    private $disabledFeaturesExclude = [];
+
+    /**
+     * @var bool
+     */
+    private ?bool $recordFullDurationMedia = null;
+
+    /**
+     * @var array
+     */
     private $breakoutRoomsGroups = [];
 
     /**
@@ -1436,6 +1446,30 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
+    public function getDisabledFeaturesExclude(): array
+    {
+        return $this->disabledFeaturesExclude;
+    }
+
+    public function setDisabledFeaturesExclude(array $disabledFeaturesExclude): CreateMeetingParameters
+    {
+        $this->disabledFeaturesExclude = $disabledFeaturesExclude;
+
+        return $this;
+    }
+
+    public function getRecordFullDurationMedia(): bool
+    {
+        return $this->recordFullDurationMedia;
+    }
+
+    public function setRecordFullDurationMedia(bool $recordFullDurationMedia): CreateMeetingParameters
+    {
+        $this->recordFullDurationMedia = $recordFullDurationMedia;
+
+        return $this;
+    }
+
     public function getBreakoutRoomsGroups(): array
     {
         return $this->breakoutRoomsGroups;
@@ -1557,9 +1591,11 @@ class CreateMeetingParameters extends MetaParameters
             'meetingExpireWhenLastUserLeftInMinutes' => $this->meetingExpireWhenLastUserLeftInMinutes,
             'preUploadedPresentationOverrideDefault' => $this->preUploadedPresentationOverrideDefault,
             'disabledFeatures'                       => join(',', $this->disabledFeatures),
+            'disabledFeaturesExclude'                => join(',', $this->disabledFeaturesExclude),
             'notifyRecordingIsOn'                    => is_null($this->notifyRecordingIsOn) ? ($this->notifyRecordingIsOn ? 'true' : 'false') : $this->notifyRecordingIsOn,
             'presentationUploadExternalUrl'          => $this->presentationUploadExternalUrl,
             'presentationUploadExternalDescription'  => $this->presentationUploadExternalDescription,
+            'recordFullDurationMedia'                => !is_null($this->recordFullDurationMedia) ? ($this->recordFullDurationMedia ? 'true' : 'false') : $this->recordFullDurationMedia,
         ];
 
         // Add breakout rooms parameters only if the meeting is a breakout room

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -89,6 +89,8 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['meetingExpireWhenLastUserLeftInMinutes'], $createMeetingParams->getMeetingExpireWhenLastUserLeftInMinutes());
         $this->assertEquals($params['preUploadedPresentationOverrideDefault'], $createMeetingParams->isPreUploadedPresentationOverrideDefault());
         $this->assertEquals($params['disabledFeatures'], $createMeetingParams->getDisabledFeatures());
+        $this->assertEquals($params['disabledFeaturesExclude'], $createMeetingParams->getDisabledFeaturesExclude());
+        $this->assertEquals($params['recordFullDurationMedia'], $createMeetingParams->getRecordFullDurationMedia());
         $this->assertEquals(json_encode($params['groups']), json_encode($createMeetingParams->getBreakoutRoomsGroups()));
         $this->assertEquals($params['meta_presenter'], $createMeetingParams->getMeta('presenter'));
         $this->assertEquals($params['meta_endCallbackUrl'], $createMeetingParams->getMeta('endCallbackUrl'));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -180,12 +180,14 @@ class TestCase extends \PHPUnit\Framework\TestCase
             'preUploadedPresentationOverrideDefault' => $this->faker->boolean,
             'groups'                                 => $this->generateBreakoutRoomsGroups(),
             'disabledFeatures'                       => $this->faker->randomElements(Feature::getValues()),
+            'disabledFeaturesExclude'                => $this->faker->randomElements(Feature::getValues()),
             'meta_presenter'                         => $this->faker->name,
             'meta_endCallbackUrl'                    => $this->faker->url,
             'meta_bbb-recording-ready-url'           => $this->faker->url,
             'notifyRecordingIsOn'                    => $this->faker->boolean(50),
             'presentationUploadExternalUrl'          => $this->faker->url,
             'presentationUploadExternalDescription'  => $this->faker->text,
+            'recordFullDurationMedia'                => $this->faker->boolean(50),
         ];
     }
 
@@ -281,6 +283,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
             ->setMeetingExpireWhenLastUserLeftInMinutes($params['meetingExpireWhenLastUserLeftInMinutes'])
             ->setPreUploadedPresentationOverrideDefault($params['preUploadedPresentationOverrideDefault'])
             ->setDisabledFeatures($params['disabledFeatures'])
+            ->setDisabledFeaturesExclude($params['disabledFeaturesExclude'])
+            ->setRecordFullDurationMedia($params['recordFullDurationMedia'])
             ->addMeta('presenter', $params['meta_presenter'])
             ->addMeta('bbb-recording-ready-url', $params['meta_bbb-recording-ready-url'])
             ->setNotifyRecordingIsOn($params['notifyRecordingIsOn'])


### PR DESCRIPTION
Two new fields have been added to CreateMeetingParameters: 'disabledFeaturesExclude' and 'recordFullDurationMedia'. With getter and setter methods, these parameters can now be set. The corresponding test cases have also been updated to account for these new fields.

**disabledFeaturesExclude**

List (comma-separated) of features to no longer disable in a particular meeting. This is particularly useful if you disabled a list of features on a per-server basis but want to allow one of two of these features for a specific meeting. (added 2.6.9)

The available options to exclude are exactly the same as for disabledFeatures


**recordFullDurationMedia**

Controls whether media (audio, cameras and screen sharing) should be captured on their full duration if the meeting's recorded property is true (recorded=true). Default is false: only captures media while recording is running in the meeting. (added 2.6.9)
Default: false