### PR TITLE
Automated updates by applying "composer cs-fix" only

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,3 +18,4 @@
     </testsuite>
   </testsuites>
 </phpunit>
+  

--- a/src/Enum/MeetingLayout.php
+++ b/src/Enum/MeetingLayout.php
@@ -20,7 +20,9 @@
 
 namespace BigBlueButton\Enum;
 
-class MeetingLayout extends \MabeEnum\Enum
+use MabeEnum\Enum;
+
+class MeetingLayout extends Enum
 {
     public const CUSTOM_LAYOUT      = 'CUSTOM_LAYOUT';
     public const SMART_LAYOUT       = 'SMART_LAYOUT';

--- a/src/Exceptions/BadResponseException.php
+++ b/src/Exceptions/BadResponseException.php
@@ -20,6 +20,4 @@
 
 namespace BigBlueButton\Exceptions;
 
-class BadResponseException extends \Exception
-{
-}
+class BadResponseException extends \Exception {}

--- a/src/Parameters/BaseParameters.php
+++ b/src/Parameters/BaseParameters.php
@@ -37,6 +37,6 @@ abstract class BaseParameters
      */
     protected function buildHTTPQuery($array)
     {
-        return str_replace(array('%20', '!', "'", "(", ")", '*'), array('+', '%21', "%27", "%28", "%29", '%2A'), http_build_query(array_filter($array), '', '&', \PHP_QUERY_RFC3986));
+        return str_replace(['%20', '!', "'", '(', ')', '*'], ['+', '%21', '%27', '%28', '%29', '%2A'], http_build_query(array_filter($array), '', '&', \PHP_QUERY_RFC3986));
     }
 }

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -27,289 +27,129 @@ class CreateMeetingParameters extends MetaParameters
 {
     use DocumentableTrait;
 
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
-    /**
-     * @var string
-     */
     private ?string $meetingName = null;
 
     /**
-     * @var string
-     *
      * @deprecated
      */
     private ?string $attendeePassword = null;
 
     /**
-     * @var string
-     *
      * @deprecated
      */
     private ?string $moderatorPassword = null;
 
-    /**
-     * @var string
-     */
     private ?string $dialNumber = null;
 
-    /**
-     * @var int
-     */
     private ?int $voiceBridge = null;
 
-    /**
-     * @var string
-     */
     private ?string $webVoice = null;
 
-    /**
-     * @var string
-     */
     private ?string $logoutUrl = null;
 
-    /**
-     * @var int
-     */
     private ?int $maxParticipants = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $record = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $autoStartRecording = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $allowStartStopRecording = null;
 
-    /**
-     * @var int
-     */
     private ?int $duration = null;
 
-    /**
-     * @var string
-     */
     private ?string $welcomeMessage = null;
 
-    /**
-     * @var string
-     */
     private ?string $moderatorOnlyMessage = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $webcamsOnlyForModerator = null;
 
-    /**
-     * @var string
-     */
     private ?string $logo = null;
 
-    /**
-     * @var string
-     */
     private ?string $copyright = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $muteOnStart = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsDisableCam = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsDisableMic = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsDisablePrivateChat = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsDisablePublicChat = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsDisableNote = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsHideUserList = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsLockedLayout = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsLockOnJoin = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsLockOnJoinConfigurable = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $lockSettingsHideViewersCursor = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $allowModsToUnmuteUsers = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $allowModsToEjectCameras = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $allowRequestsWithoutSession = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $isBreakout = null;
 
-    /**
-     * @var string
-     */
     private ?string $parentMeetingId = null;
 
-    /**
-     * @var int
-     */
     private ?int $sequence = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $freeJoin = null;
 
-    /**
-     * @var string
-     */
     private ?string $guestPolicy = null;
 
-    /**
-     * @var string
-     */
     private ?string $bannerText = null;
 
-    /**
-     * @var string
-     */
     private ?string $bannerColor = null;
 
     /**
      * @deprecated
-     *
-     * @var bool
      */
     private ?bool $learningDashboardEnabled = null;
 
     /**
      * @deprecated
-     *
-     * @var bool
      */
     private ?bool $virtualBackgroundsDisabled = null;
 
-    /**
-     * @var int
-     */
     private ?int $learningDashboardCleanupDelayInMinutes = null;
 
-    /**
-     * @var int
-     */
     private ?int $endWhenNoModeratorDelayInMinutes = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $endWhenNoModerator = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $meetingKeepEvents = null;
 
     /**
      * @deprecated
-     *
-     * @var bool
      */
     private ?bool $breakoutRoomsEnabled = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $breakoutRoomsRecord = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $breakoutRoomsPrivateChatEnabled = null;
 
-    /**
-     * @var string
-     */
     private ?string $meetingEndedURL = null;
 
-    /**
-     * @var string
-     */
     private ?string $meetingLayout = null;
 
-    /**
-     * @var int
-     */
     private ?int $userCameraCap = null;
 
-    /**
-     * @var int
-     */
     private ?int $meetingCameraCap = null;
 
-    /**
-     * @var int
-     */
     private ?int $meetingExpireIfNoUserJoinedInMinutes = null;
 
-    /**
-     * @var int
-     */
     private ?int $meetingExpireWhenLastUserLeftInMinutes = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $preUploadedPresentationOverrideDefault = null;
 
     /**
@@ -322,19 +162,10 @@ class CreateMeetingParameters extends MetaParameters
      */
     private $breakoutRoomsGroups = [];
 
-    /**
-     * @var bool
-     */
     private ?bool $notifyRecordingIsOn = null;
 
-    /**
-     * @var string
-     */
     private ?string $presentationUploadExternalUrl = null;
 
-    /**
-     * @var string
-     */
     private ?string $presentationUploadExternalDescription = null;
 
     /**

--- a/src/Parameters/DeleteRecordingsParameters.php
+++ b/src/Parameters/DeleteRecordingsParameters.php
@@ -25,9 +25,6 @@ namespace BigBlueButton\Parameters;
  */
 class DeleteRecordingsParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $recordingId = null;
 
     /**

--- a/src/Parameters/EndMeetingParameters.php
+++ b/src/Parameters/EndMeetingParameters.php
@@ -25,15 +25,10 @@ namespace BigBlueButton\Parameters;
  */
 class EndMeetingParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
     /**
      * @deprecated
-     *
-     * @var string
      */
     private ?string $password = null;
 

--- a/src/Parameters/GetMeetingInfoParameters.php
+++ b/src/Parameters/GetMeetingInfoParameters.php
@@ -25,19 +25,10 @@ namespace BigBlueButton\Parameters;
  */
 class GetMeetingInfoParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
-    /**
-     * @var int
-     */
     private ?int $offset = null;
 
-    /**
-     * @var int
-     */
     private ?int $limit = null;
 
     /**

--- a/src/Parameters/GetRecordingTextTracksParameters.php
+++ b/src/Parameters/GetRecordingTextTracksParameters.php
@@ -25,9 +25,6 @@ namespace BigBlueButton\Parameters;
  */
 class GetRecordingTextTracksParameters extends MetaParameters
 {
-    /**
-     * @var string
-     */
     private ?string $recordId = null;
 
     /**

--- a/src/Parameters/GetRecordingsParameters.php
+++ b/src/Parameters/GetRecordingsParameters.php
@@ -25,19 +25,10 @@ namespace BigBlueButton\Parameters;
  */
 class GetRecordingsParameters extends MetaParameters
 {
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
-    /**
-     * @var string
-     */
     private ?string $recordId = null;
 
-    /**
-     * @var string
-     */
     private ?string $state = null;
 
     /**

--- a/src/Parameters/HooksCreateParameters.php
+++ b/src/Parameters/HooksCreateParameters.php
@@ -22,19 +22,10 @@ namespace BigBlueButton\Parameters;
 
 class HooksCreateParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $callbackUrl = null;
 
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $getRaw = null;
 
     /**

--- a/src/Parameters/HooksDestroyParameters.php
+++ b/src/Parameters/HooksDestroyParameters.php
@@ -22,9 +22,6 @@ namespace BigBlueButton\Parameters;
 
 class HooksDestroyParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $hookId = null;
 
     /**

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -27,10 +27,7 @@ class InsertDocumentParameters extends BaseParameters
 {
     use DocumentableTrait;
 
-    /**
-     * @var string
-     */
-    private ?string  $meetingId = null;
+    private ?string $meetingId = null;
 
     /**
      * EndMeetingParameters constructor.

--- a/src/Parameters/IsMeetingRunningParameters.php
+++ b/src/Parameters/IsMeetingRunningParameters.php
@@ -25,9 +25,6 @@ namespace BigBlueButton\Parameters;
  */
 class IsMeetingRunningParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
     /**

--- a/src/Parameters/JoinMeetingParameters.php
+++ b/src/Parameters/JoinMeetingParameters.php
@@ -27,51 +27,25 @@ use BigBlueButton\Enum\Role;
  */
 class JoinMeetingParameters extends UserDataParameters
 {
-    /**
-     * @var string
-     */
     private ?string $meetingId = null;
 
-    /**
-     * @var string
-     */
     private ?string $username = null;
 
     /**
-     * @var string
-     *
      * @deprecated
      */
     private ?string $password = null;
 
-    /**
-     * @var string
-     */
     private ?string $userId = null;
 
-    /**
-     * @var string
-     */
     private ?string $webVoiceConf = null;
 
-    /**
-     * @var string
-     */
     private ?string $creationTime = null;
 
-    /**
-     * @var string
-     */
     private ?string $avatarURL = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $redirect = null;
 
-    /**
-     * @var string
-     */
     private ?string $clientURL = null;
 
     /**
@@ -79,29 +53,14 @@ class JoinMeetingParameters extends UserDataParameters
      */
     private $customParameters;
 
-    /**
-     * @var string
-     */
     private ?string $role = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $excludeFromDashboard = null;
 
-    /**
-     * @var string
-     */
     private ?string $configToken = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $guest = null;
 
-    /**
-     * @var string
-     */
     private ?string $defaultLayout = null;
 
     /**
@@ -437,7 +396,6 @@ class JoinMeetingParameters extends UserDataParameters
             'guest'                => !is_null($this->guest) ? ($this->guest ? 'true' : 'false') : $this->guest,
             'defaultLayout'        => $this->defaultLayout,
         ];
-        
 
         foreach ($this->customParameters as $key => $value) {
             $queries[$key] = $value;

--- a/src/Parameters/PublishRecordingsParameters.php
+++ b/src/Parameters/PublishRecordingsParameters.php
@@ -25,14 +25,8 @@ namespace BigBlueButton\Parameters;
  */
 class PublishRecordingsParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $recordingId = null;
 
-    /**
-     * @var bool
-     */
     private ?bool $publish = null;
 
     /**

--- a/src/Parameters/PutRecordingTextTrackParameters.php
+++ b/src/Parameters/PutRecordingTextTrackParameters.php
@@ -25,24 +25,12 @@ namespace BigBlueButton\Parameters;
  */
 class PutRecordingTextTrackParameters extends BaseParameters
 {
-    /**
-     * @var string
-     */
     private ?string $recordId = null;
 
-    /**
-     * @var string
-     */
     private ?string $kind = null;
 
-    /**
-     * @var string
-     */
     private ?string $lang = null;
 
-    /**
-     * @var string
-     */
     private ?string $label = null;
 
     /**

--- a/src/Parameters/UpdateRecordingsParameters.php
+++ b/src/Parameters/UpdateRecordingsParameters.php
@@ -25,9 +25,6 @@ namespace BigBlueButton\Parameters;
  */
 class UpdateRecordingsParameters extends MetaParameters
 {
-    /**
-     * @var string
-     */
     private ?string $recordingId = null;
 
     /**

--- a/src/Responses/InsertDocumentResponse.php
+++ b/src/Responses/InsertDocumentResponse.php
@@ -20,6 +20,4 @@
 
 namespace BigBlueButton\Responses;
 
-class InsertDocumentResponse extends BaseResponse
-{
-}
+class InsertDocumentResponse extends BaseResponse {}

--- a/src/Util/ParamsIterator.php
+++ b/src/Util/ParamsIterator.php
@@ -29,13 +29,10 @@ use BigBlueButton\TestCase;
  */
 class ParamsIterator extends TestCase
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function iterate($params, $url)
     {
-       
         foreach ($params as $key => $value) {
             if (is_bool($value)) {
                 $value = $value ? 'true' : 'false';

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -83,7 +83,6 @@ class BigBlueButtonTest extends TestCase
         $params = $this->generateCreateParams();
         $url    = $this->bbb->getCreateMeetingUrl($this->getCreateMock($params));
 
-      
         $paramsIterator = new ParamsIterator();
         $paramsIterator->iterate($params, $url);
     }

--- a/tests/Responses/ApiVersionResponseTest.php
+++ b/tests/Responses/ApiVersionResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class ApiVersionResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\ApiVersionResponse
+     * @var ApiVersionResponse
      */
     private $version;
 

--- a/tests/Responses/CreateMeetingResponseTest.php
+++ b/tests/Responses/CreateMeetingResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class CreateMeetingResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\CreateMeetingResponse
+     * @var CreateMeetingResponse
      */
     private $meeting;
 

--- a/tests/Responses/DeleteRecordingsResponseTest.php
+++ b/tests/Responses/DeleteRecordingsResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class DeleteRecordingsResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\DeleteRecordingsResponse
+     * @var DeleteRecordingsResponse
      */
     private $delete;
 

--- a/tests/Responses/EndMeetingResponseTest.php
+++ b/tests/Responses/EndMeetingResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class EndMeetingResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\EndMeetingResponse
+     * @var EndMeetingResponse
      */
     private $end;
 

--- a/tests/Responses/GetMeetingInfoResponseTest.php
+++ b/tests/Responses/GetMeetingInfoResponseTest.php
@@ -20,6 +20,8 @@
 
 namespace BigBlueButton\Responses;
 
+use BigBlueButton\TestCase;
+
 /*
  * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
  *
@@ -59,10 +61,10 @@ namespace BigBlueButton\Responses;
  *
  * @coversNothing
  */
-class GetMeetingInfoResponseTest extends \BigBlueButton\TestCase
+class GetMeetingInfoResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\GetMeetingInfoResponse
+     * @var GetMeetingInfoResponse
      */
     private $meetingInfo;
 
@@ -72,7 +74,7 @@ class GetMeetingInfoResponseTest extends \BigBlueButton\TestCase
 
         $xml = $this->loadXmlFile(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'get_meeting_info.xml');
 
-        $this->meetingInfo = new \BigBlueButton\Responses\GetMeetingInfoResponse($xml);
+        $this->meetingInfo = new GetMeetingInfoResponse($xml);
     }
 
     public function testGetMeetingInfoResponseContent()

--- a/tests/Responses/GetMeetingsResponseTest.php
+++ b/tests/Responses/GetMeetingsResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class GetMeetingsResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\GetMeetingsResponse
+     * @var GetMeetingsResponse
      */
     private $meetings;
 

--- a/tests/Responses/GetRecordingsResponseTest.php
+++ b/tests/Responses/GetRecordingsResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class GetRecordingsResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\GetRecordingsResponse
+     * @var GetRecordingsResponse
      */
     private $records;
 

--- a/tests/Responses/HooksCreateResponseTest.php
+++ b/tests/Responses/HooksCreateResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class HooksCreateResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\HooksCreateResponse
+     * @var HooksCreateResponse
      */
     private $createResponse;
 

--- a/tests/Responses/HooksDestroyResponseTest.php
+++ b/tests/Responses/HooksDestroyResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class HooksDestroyResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\HooksDestroyResponse
+     * @var HooksDestroyResponse
      */
     private $destroyResponse;
 

--- a/tests/Responses/HooksListResponseTest.php
+++ b/tests/Responses/HooksListResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class HooksListResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\HooksListResponse
+     * @var HooksListResponse
      */
     private $listResponse;
 

--- a/tests/Responses/InsertDocumentResponseTest.php
+++ b/tests/Responses/InsertDocumentResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class InsertDocumentResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\InsertDocumentResponse
+     * @var InsertDocumentResponse
      */
     private $insertDocument;
 

--- a/tests/Responses/IsMeetingRunningResponseTest.php
+++ b/tests/Responses/IsMeetingRunningResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class IsMeetingRunningResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\IsMeetingRunningResponse
+     * @var IsMeetingRunningResponse
      */
     private $running;
 

--- a/tests/Responses/JoinMeetingResponseTest.php
+++ b/tests/Responses/JoinMeetingResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class JoinMeetingResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\JoinMeetingResponse
+     * @var JoinMeetingResponse
      */
     private $joinMeeting;
 

--- a/tests/Responses/PublishRecordingsResponseTest.php
+++ b/tests/Responses/PublishRecordingsResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class PublishRecordingsResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\PublishRecordingsResponse
+     * @var PublishRecordingsResponse
      */
     private $publish;
 

--- a/tests/Responses/UpdateRecordingsResponseTest.php
+++ b/tests/Responses/UpdateRecordingsResponseTest.php
@@ -30,7 +30,7 @@ use BigBlueButton\TestCase;
 class UpdateRecordingsResponseTest extends TestCase
 {
     /**
-     * @var \BigBlueButton\Responses\UpdateRecordingsResponse
+     * @var UpdateRecordingsResponse
      */
     private $update;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,5 +22,6 @@ error_reporting(-1);
 date_default_timezone_set('UTC');
 // Include the composer autoloader
 $loader = require_once __DIR__ . '/../vendor/autoload.php';
+
 // Include custom test class
 require_once __DIR__ . '/TestCase.php';


### PR DESCRIPTION
These updates have been done automatically after a fresh installation (`composer install`) and running `composer cs-fix`.
Seems to be that couple of updates (like removing redundant annotations) are connected to the new php7.4 minimum.