### PR TITLE
Implement usage of DOTENV-files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# Specify the value of your BigBlueButton secret
+BBB_SERVER_BASE_URL="https://test-install.blindsidenetworks.com/bigbluebutton/"
+
+# Specify the Server Base URL of your BigBlueButton
+BBB_SECRET="8cd8ef52e8e101574e400365b55e11a6"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ composer.phar
 composer.lock
 .DS_Store
 
+## local environment variables
+.env.local
+
 ## Directory-based project format:
 .idea/
 /nbproject

--- a/README.md
+++ b/README.md
@@ -56,14 +56,30 @@ $ ./vendor/bin/phpstan analyse
 For every implemented feature add unit tests and check all is green by running the command below.
 
 ```bash
+# using an alias
 $ composer test
+
+# or the same w/o alias
+./vendor/bin/phpunit
 ```
 
 To run a single test
 
 ```bash
-./vendor/bin/phpunit --filter "BigBlueButtonTest::testApiVersion"
+# using an alias
+$ composer test -- --filter BigBlueButtonTest::testApiVersion
+
+# or the same w/o alias
+./vendor/bin/phpunit --filter BigBlueButtonTest::testApiVersion
 ```
+
+**Remark:**
+
+Some test will connect to an existing BBB-server, which is specified in the `.env`-file. You 
+can specify your own BBB-server by copy that file into the same folder and name it `.env.local`.
+Exchange the credentials `BBB_SERVER_BASE_URL` and `BBB_SECRET` to your server's values.
+Since this new file (`.env.local`) takes precedence over the main file (`.env`), you will now test 
+with your own server.
 
 [bbb]: http://bigbluebutton.org
 [composer]: https://getcomposer.org

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "phpmetrics/phpmetrics": "^v2.8.2",
     "wapmorgan/php-deprecation-detector": "^2.0.33",
     "phpstan/phpstan": "^1.10",
-    "tracy/tracy": "^2.10"
+    "tracy/tracy": "^2.10",
+    "vlucas/phpdotenv": "^5.6"
   },
   "scripts": {
     "code-check": "./vendor/bin/phpstan analyse",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,10 +7,6 @@
   </coverage>
   <php>
     <env name="XDEBUG_MODE" value="coverage"/>
-    <!-- Specify the value of your BigBlueButton secret -->
-    <env name="BBB_SECRET" value="8cd8ef52e8e101574e400365b55e11a6"/>
-    <!-- Specify the Server Base URL of your BigBlueButton -->
-    <env name="BBB_SERVER_BASE_URL" value="https://test-install.blindsidenetworks.com/bigbluebutton/"/>
   </php>
   <testsuites>
     <testsuite name="BigBlueButton test suite">

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -29,6 +29,7 @@ use BigBlueButton\Parameters\GetRecordingsParameters;
 use BigBlueButton\Parameters\IsMeetingRunningParameters;
 use BigBlueButton\Parameters\PublishRecordingsParameters;
 use BigBlueButton\Util\ParamsIterator;
+use Dotenv\Dotenv;
 
 /**
  * Class BigBlueButtonTest.
@@ -48,12 +49,7 @@ class BigBlueButtonTest extends TestCase
     {
         parent::setUp();
 
-        foreach (['BBB_SECRET', 'BBB_SERVER_BASE_URL'] as $key) {
-            if (!getenv($key)) {
-                $this->fail('$_SERVER[\'' . $key . '\'] not set in '
-                    . 'phpunit.xml');
-            }
-        }
+        $this->loadEnvironmentVariables();
 
         $this->bbb = new BigBlueButton();
     }
@@ -358,5 +354,27 @@ class BigBlueButtonTest extends TestCase
         $result = $this->bbb->updateRecordings($this->getUpdateRecordingsParamsMock($params));
         $this->assertEquals('FAILED', $result->getReturnCode());
         $this->assertTrue($result->failed());
+    }
+
+    /**
+     * @see https://github.com/vlucas/phpdotenv
+     */
+    private function loadEnvironmentVariables(): void
+    {
+        $envPath      = __DIR__ . '/..';
+        $envFileMain  = '.env';
+        $envFileLocal = '.env.local';
+
+        if (file_exists("{$envPath}/{$envFileLocal}")) {
+            $envFile = $envFileLocal;
+        } elseif (file_exists("{$envPath}/{$envFileMain}")) {
+            $envFile = $envFileMain;
+        } else {
+            throw new \RuntimeException("Environment file ('{$envFileMain}' nor '{$envFileLocal}') not found!");
+        }
+
+        $dotenv = Dotenv::createUnsafeImmutable($envPath, $envFile);
+        $dotenv->load();
+        $dotenv->required(['BBB_SECRET', 'BBB_SERVER_BASE_URL']);
     }
 }


### PR DESCRIPTION
## Background
Some tests are depending on a real server. If that server has an unexpected configuration these test will fail. Up to now the credentials of that real server are hard-wired.

## Proposal
With this solution it is possible to use a `.env.local` file which will override the BBB-credentials with another server. So test will be in best case successful :-) The advantage of the usage of an `.env.locale`-file is, that it will not be committed and pushed to the repository.

## Links
This PR will potentially close [Issue 69](https://github.com/bigbluebutton/bigbluebutton-api-php/issues/69).