### PR TITLE
Downgrad Tracy to v2.9 (and keep scrutinizer on php 8.1)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,7 +5,7 @@ build:
         override: true
       environment:
         php:
-          version: 8.1
+          version: 7.4
           compile_options: '--with-openssl --with-curl --enable-mbstring --enable-mbregex --enable-bcmath --with-mhash --with-xmlrpc --enable-opcache --enable-intl --with-pear --enable-fpm --with-zlib-dir --enable-inline-optimization --with-bz2 --with-zlib'
       tests:
         override:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,7 +5,7 @@ build:
         override: true
       environment:
         php:
-          version: 7.4
+          version: 8.1
           compile_options: '--with-openssl --with-curl --enable-mbstring --enable-mbregex --enable-bcmath --with-mhash --with-xmlrpc --enable-opcache --enable-intl --with-pear --enable-fpm --with-zlib-dir --enable-inline-optimization --with-bz2 --with-zlib'
       tests:
         override:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "phpmetrics/phpmetrics": "^v2.8.2",
     "wapmorgan/php-deprecation-detector": "^2.0.33",
     "phpstan/phpstan": "^1.10",
-    "tracy/tracy": "^2.10",
+    "tracy/tracy": "2.9",
     "vlucas/phpdotenv": "^5.6"
   },
   "scripts": {


### PR DESCRIPTION
## Background
The automatically installed version of TRACY (v2.10) is not compatible with php7.4

## Proposal
Hardwire TRACY to v2.9 in `composer.json`

## Remark
Previous proposed change of scrutinizer has been rolled back. 