### PR TITLE
Improve UrlBuilder (SOLID - Seperation of Concern)

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -20,7 +20,6 @@
 
 namespace BigBlueButton;
 
-use BigBlueButton\Core\ApiMethod;
 use BigBlueButton\Enum\HashingAlgorithm;
 use BigBlueButton\Exceptions\BadResponseException;
 use BigBlueButton\Parameters\CreateMeetingParameters;
@@ -62,10 +61,10 @@ class BigBlueButton
 {
     protected string $bbbSecret;
     protected string $bbbBaseUrl;
-    protected UrlBuilder $urlBuilder;
     protected string $jSessionId;
-
     protected string $hashingAlgorithm;
+
+    protected UrlBuilder $urlBuilder;
 
     /**
      * @var array<int, mixed>
@@ -102,6 +101,9 @@ class BigBlueButton
         $this->curlOpts         = $opts['curl'] ?? [];
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function setHashingAlgorithm(string $hashingAlgorithm): void
     {
         $this->hashingAlgorithm = $hashingAlgorithm;
@@ -126,9 +128,12 @@ class BigBlueButton
     -- insertDocument
     */
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getCreateMeetingUrl(CreateMeetingParameters $createMeetingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::CREATE, $createMeetingParams->getHTTPQuery());
+        return $this->urlBuilder->getCreateMeetingUrl($createMeetingParams);
     }
 
     /**
@@ -136,14 +141,17 @@ class BigBlueButton
      */
     public function createMeeting(CreateMeetingParameters $createMeetingParams): CreateMeetingResponse
     {
-        $xml = $this->processXmlResponse($this->getCreateMeetingUrl($createMeetingParams), $createMeetingParams->getPresentationsAsXML());
+        $xml = $this->processXmlResponse($this->urlBuilder->getCreateMeetingUrl($createMeetingParams), $createMeetingParams->getPresentationsAsXML());
 
         return new CreateMeetingResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getJoinMeetingURL(JoinMeetingParameters $joinMeetingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::JOIN, $joinMeetingParams->getHTTPQuery());
+        return $this->urlBuilder->getJoinMeetingURL($joinMeetingParams);
     }
 
     /**
@@ -151,14 +159,17 @@ class BigBlueButton
      */
     public function joinMeeting(JoinMeetingParameters $joinMeetingParams): JoinMeetingResponse
     {
-        $xml = $this->processXmlResponse($this->getJoinMeetingURL($joinMeetingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getJoinMeetingURL($joinMeetingParams));
 
         return new JoinMeetingResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getEndMeetingURL(EndMeetingParameters $endParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::END, $endParams->getHTTPQuery());
+        return $this->urlBuilder->getEndMeetingURL($endParams);
     }
 
     /**
@@ -166,14 +177,17 @@ class BigBlueButton
      */
     public function endMeeting(EndMeetingParameters $endParams): EndMeetingResponse
     {
-        $xml = $this->processXmlResponse($this->getEndMeetingURL($endParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getEndMeetingURL($endParams));
 
         return new EndMeetingResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getInsertDocumentUrl(InsertDocumentParameters $insertDocumentParameters): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::INSERT_DOCUMENT, $insertDocumentParameters->getHTTPQuery());
+        return $this->urlBuilder->getInsertDocumentUrl($insertDocumentParameters);
     }
 
     /**
@@ -181,7 +195,7 @@ class BigBlueButton
      */
     public function insertDocument(InsertDocumentParameters $insertDocumentParams): CreateMeetingResponse
     {
-        $xml = $this->processXmlResponse($this->getInsertDocumentUrl($insertDocumentParams), $insertDocumentParams->getPresentationsAsXML());
+        $xml = $this->processXmlResponse($this->urlBuilder->getInsertDocumentUrl($insertDocumentParams), $insertDocumentParams->getPresentationsAsXML());
 
         return new CreateMeetingResponse($xml);
     }
@@ -193,9 +207,12 @@ class BigBlueButton
     -- getMeetingInfo
     */
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getIsMeetingRunningUrl(IsMeetingRunningParameters $meetingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::IS_MEETING_RUNNING, $meetingParams->getHTTPQuery());
+        return $this->urlBuilder->getIsMeetingRunningUrl($meetingParams);
     }
 
     /**
@@ -203,14 +220,17 @@ class BigBlueButton
      */
     public function isMeetingRunning(IsMeetingRunningParameters $meetingParams): IsMeetingRunningResponse
     {
-        $xml = $this->processXmlResponse($this->getIsMeetingRunningUrl($meetingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getIsMeetingRunningUrl($meetingParams));
 
         return new IsMeetingRunningResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getMeetingsUrl(): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::GET_MEETINGS);
+        return $this->urlBuilder->getMeetingsUrl();
     }
 
     /**
@@ -218,14 +238,17 @@ class BigBlueButton
      */
     public function getMeetings(): GetMeetingsResponse
     {
-        $xml = $this->processXmlResponse($this->getMeetingsUrl());
+        $xml = $this->processXmlResponse($this->urlBuilder->getMeetingsUrl());
 
         return new GetMeetingsResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getMeetingInfoUrl(GetMeetingInfoParameters $meetingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::GET_MEETING_INFO, $meetingParams->getHTTPQuery());
+        return $this->urlBuilder->getMeetingInfoUrl($meetingParams);
     }
 
     /**
@@ -233,7 +256,7 @@ class BigBlueButton
      */
     public function getMeetingInfo(GetMeetingInfoParameters $meetingParams): GetMeetingInfoResponse
     {
-        $xml = $this->processXmlResponse($this->getMeetingInfoUrl($meetingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getMeetingInfoUrl($meetingParams));
 
         return new GetMeetingInfoResponse($xml);
     }
@@ -245,9 +268,12 @@ class BigBlueButton
     -- deleteRecordings
     */
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getRecordingsUrl(GetRecordingsParameters $recordingsParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::GET_RECORDINGS, $recordingsParams->getHTTPQuery());
+        return $this->urlBuilder->getRecordingsUrl($recordingsParams);
     }
 
     /**
@@ -257,26 +283,35 @@ class BigBlueButton
      */
     public function getRecordings($recordingParams): GetRecordingsResponse
     {
-        $xml = $this->processXmlResponse($this->getRecordingsUrl($recordingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getRecordingsUrl($recordingParams));
 
         return new GetRecordingsResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getPublishRecordingsUrl(PublishRecordingsParameters $recordingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::PUBLISH_RECORDINGS, $recordingParams->getHTTPQuery());
+        return $this->urlBuilder->getPublishRecordingsUrl($recordingParams);
     }
 
+    /**
+     * @throws BadResponseException
+     */
     public function publishRecordings(PublishRecordingsParameters $recordingParams): PublishRecordingsResponse
     {
-        $xml = $this->processXmlResponse($this->getPublishRecordingsUrl($recordingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getPublishRecordingsUrl($recordingParams));
 
         return new PublishRecordingsResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getDeleteRecordingsUrl(DeleteRecordingsParameters $recordingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::DELETE_RECORDINGS, $recordingParams->getHTTPQuery());
+        return $this->urlBuilder->getDeleteRecordingsUrl($recordingParams);
     }
 
     /**
@@ -284,14 +319,17 @@ class BigBlueButton
      */
     public function deleteRecordings(DeleteRecordingsParameters $recordingParams): DeleteRecordingsResponse
     {
-        $xml = $this->processXmlResponse($this->getDeleteRecordingsUrl($recordingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getDeleteRecordingsUrl($recordingParams));
 
         return new DeleteRecordingsResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getUpdateRecordingsUrl(UpdateRecordingsParameters $recordingParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::UPDATE_RECORDINGS, $recordingParams->getHTTPQuery());
+        return $this->urlBuilder->getUpdateRecordingsUrl($recordingParams);
     }
 
     /**
@@ -299,40 +337,55 @@ class BigBlueButton
      */
     public function updateRecordings(UpdateRecordingsParameters $recordingParams): UpdateRecordingsResponse
     {
-        $xml = $this->processXmlResponse($this->getUpdateRecordingsUrl($recordingParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getUpdateRecordingsUrl($recordingParams));
 
         return new UpdateRecordingsResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getRecordingTextTracksUrl(GetRecordingTextTracksParameters $getRecordingTextTracksParameters): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::GET_RECORDING_TEXT_TRACKS, $getRecordingTextTracksParameters->getHTTPQuery());
+        return $this->urlBuilder->getRecordingTextTracksUrl($getRecordingTextTracksParameters);
     }
 
+    /**
+     * @throws BadResponseException
+     */
     public function getRecordingTextTracks(GetRecordingTextTracksParameters $getRecordingTextTracksParams): GetRecordingTextTracksResponse
     {
-        $json = $this->processJsonResponse($this->getRecordingTextTracksUrl($getRecordingTextTracksParams));
+        $json = $this->processJsonResponse($this->urlBuilder->getRecordingTextTracksUrl($getRecordingTextTracksParams));
 
         return new GetRecordingTextTracksResponse($json);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getPutRecordingTextTrackUrl(PutRecordingTextTrackParameters $putRecordingTextTrackParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::PUT_RECORDING_TEXT_TRACK, $putRecordingTextTrackParams->getHTTPQuery());
+        return $this->urlBuilder->getPutRecordingTextTrackUrl($putRecordingTextTrackParams);
     }
 
+    /**
+     * @throws BadResponseException
+     */
     public function putRecordingTextTrack(PutRecordingTextTrackParameters $putRecordingTextTrackParams): PutRecordingTextTrackResponse
     {
-        $json = $this->processJsonResponse($this->getPutRecordingTextTrackUrl($putRecordingTextTrackParams));
+        $json = $this->processJsonResponse($this->urlBuilder->getPutRecordingTextTrackUrl($putRecordingTextTrackParams));
 
         return new PutRecordingTextTrackResponse($json);
     }
 
     // ____________________ WEB HOOKS METHODS ___________________
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getHooksCreateUrl(HooksCreateParameters $hookCreateParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_CREATE, $hookCreateParams->getHTTPQuery());
+        return $this->urlBuilder->getHooksCreateUrl($hookCreateParams);
     }
 
     /**
@@ -342,26 +395,35 @@ class BigBlueButton
      */
     public function hooksCreate($hookCreateParams): HooksCreateResponse
     {
-        $xml = $this->processXmlResponse($this->getHooksCreateUrl($hookCreateParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getHooksCreateUrl($hookCreateParams));
 
         return new HooksCreateResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getHooksListUrl(): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_LIST);
+        return $this->urlBuilder->getHooksListUrl();
     }
 
+    /**
+     * @throws BadResponseException
+     */
     public function hooksList(): HooksListResponse
     {
-        $xml = $this->processXmlResponse($this->getHooksListUrl());
+        $xml = $this->processXmlResponse($this->urlBuilder->getHooksListUrl());
 
         return new HooksListResponse($xml);
     }
 
+    /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-class
+     */
     public function getHooksDestroyUrl(HooksDestroyParameters $hooksDestroyParams): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_DESTROY, $hooksDestroyParams->getHTTPQuery());
+        return $this->urlBuilder->getHooksDestroyUrl($hooksDestroyParams);
     }
 
     /**
@@ -371,7 +433,7 @@ class BigBlueButton
      */
     public function hooksDestroy($hooksDestroyParams): HooksDestroyResponse
     {
-        $xml = $this->processXmlResponse($this->getHooksDestroyUrl($hooksDestroyParams));
+        $xml = $this->processXmlResponse($this->urlBuilder->getHooksDestroyUrl($hooksDestroyParams));
 
         return new HooksDestroyResponse($xml);
     }
@@ -407,6 +469,8 @@ class BigBlueButton
     }
 
     /**
+     * @deprecated Replaced by same function-name provided by UrlBuilder-BigBlueButton
+     *
      * Public accessor for buildUrl.
      */
     public function buildUrl(string $method = '', string $params = '', bool $append = true): string
@@ -503,9 +567,9 @@ class BigBlueButton
      *
      * @throws BadResponseException|\Exception
      */
-    private function processXmlResponse(string $url, string $payload = '', string $contentType = 'application/xml'): \SimpleXMLElement
+    private function processXmlResponse(string $url, string $payload = ''): \SimpleXMLElement
     {
-        return new \SimpleXMLElement($this->sendRequest($url, $payload, $contentType));
+        return new \SimpleXMLElement($this->sendRequest($url, $payload, 'application/xml'));
     }
 
     /**
@@ -513,8 +577,8 @@ class BigBlueButton
      *
      * @throws BadResponseException
      */
-    private function processJsonResponse(string $url, string $payload = '', string $contentType = 'application/json'): string
+    private function processJsonResponse(string $url, string $payload = ''): string
     {
-        return $this->sendRequest($url, $payload, $contentType);
+        return $this->sendRequest($url, $payload, 'application/json');
     }
 }

--- a/src/Util/UrlBuilder.php
+++ b/src/Util/UrlBuilder.php
@@ -20,6 +20,22 @@
 
 namespace BigBlueButton\Util;
 
+use BigBlueButton\Core\ApiMethod;
+use BigBlueButton\Parameters\CreateMeetingParameters;
+use BigBlueButton\Parameters\DeleteRecordingsParameters;
+use BigBlueButton\Parameters\EndMeetingParameters;
+use BigBlueButton\Parameters\GetMeetingInfoParameters;
+use BigBlueButton\Parameters\GetRecordingsParameters;
+use BigBlueButton\Parameters\GetRecordingTextTracksParameters;
+use BigBlueButton\Parameters\HooksCreateParameters;
+use BigBlueButton\Parameters\HooksDestroyParameters;
+use BigBlueButton\Parameters\InsertDocumentParameters;
+use BigBlueButton\Parameters\IsMeetingRunningParameters;
+use BigBlueButton\Parameters\JoinMeetingParameters;
+use BigBlueButton\Parameters\PublishRecordingsParameters;
+use BigBlueButton\Parameters\PutRecordingTextTrackParameters;
+use BigBlueButton\Parameters\UpdateRecordingsParameters;
+
 /**
  * Class UrlBuilder.
  */
@@ -60,5 +76,86 @@ class UrlBuilder
     public function buildQs(string $method = '', string $params = ''): string
     {
         return $params . '&checksum=' . hash($this->hashingAlgorithm, $method . $params . $this->securitySalt);
+    }
+
+    // URL-Generators
+    public function getCreateMeetingUrl(CreateMeetingParameters $createMeetingParams): string
+    {
+        return $this->buildUrl(ApiMethod::CREATE, $createMeetingParams->getHTTPQuery());
+    }
+
+    public function getJoinMeetingURL(JoinMeetingParameters $joinMeetingParams): string
+    {
+        return $this->buildUrl(ApiMethod::JOIN, $joinMeetingParams->getHTTPQuery());
+    }
+
+    public function getEndMeetingURL(EndMeetingParameters $endParams): string
+    {
+        return $this->buildUrl(ApiMethod::END, $endParams->getHTTPQuery());
+    }
+
+    public function getInsertDocumentUrl(InsertDocumentParameters $insertDocumentParameters): string
+    {
+        return $this->buildUrl(ApiMethod::INSERT_DOCUMENT, $insertDocumentParameters->getHTTPQuery());
+    }
+
+    public function getIsMeetingRunningUrl(IsMeetingRunningParameters $meetingParams): string
+    {
+        return $this->buildUrl(ApiMethod::IS_MEETING_RUNNING, $meetingParams->getHTTPQuery());
+    }
+
+    public function getMeetingsUrl(): string
+    {
+        return $this->buildUrl(ApiMethod::GET_MEETINGS);
+    }
+
+    public function getMeetingInfoUrl(GetMeetingInfoParameters $meetingParams): string
+    {
+        return $this->buildUrl(ApiMethod::GET_MEETING_INFO, $meetingParams->getHTTPQuery());
+    }
+
+    public function getRecordingsUrl(GetRecordingsParameters $recordingsParams): string
+    {
+        return $this->buildUrl(ApiMethod::GET_RECORDINGS, $recordingsParams->getHTTPQuery());
+    }
+
+    public function getPublishRecordingsUrl(PublishRecordingsParameters $recordingParams): string
+    {
+        return $this->buildUrl(ApiMethod::PUBLISH_RECORDINGS, $recordingParams->getHTTPQuery());
+    }
+
+    public function getDeleteRecordingsUrl(DeleteRecordingsParameters $recordingParams): string
+    {
+        return $this->buildUrl(ApiMethod::DELETE_RECORDINGS, $recordingParams->getHTTPQuery());
+    }
+
+    public function getUpdateRecordingsUrl(UpdateRecordingsParameters $recordingParams): string
+    {
+        return $this->buildUrl(ApiMethod::UPDATE_RECORDINGS, $recordingParams->getHTTPQuery());
+    }
+
+    public function getRecordingTextTracksUrl(GetRecordingTextTracksParameters $getRecordingTextTracksParameters): string
+    {
+        return $this->buildUrl(ApiMethod::GET_RECORDING_TEXT_TRACKS, $getRecordingTextTracksParameters->getHTTPQuery());
+    }
+
+    public function getPutRecordingTextTrackUrl(PutRecordingTextTrackParameters $putRecordingTextTrackParams): string
+    {
+        return $this->buildUrl(ApiMethod::PUT_RECORDING_TEXT_TRACK, $putRecordingTextTrackParams->getHTTPQuery());
+    }
+
+    public function getHooksCreateUrl(HooksCreateParameters $hookCreateParams): string
+    {
+        return $this->buildUrl(ApiMethod::HOOKS_CREATE, $hookCreateParams->getHTTPQuery());
+    }
+
+    public function getHooksListUrl(): string
+    {
+        return $this->buildUrl(ApiMethod::HOOKS_LIST);
+    }
+
+    public function getHooksDestroyUrl(HooksDestroyParameters $hooksDestroyParams): string
+    {
+        return $this->buildUrl(ApiMethod::HOOKS_DESTROY, $hooksDestroyParams->getHTTPQuery());
     }
 }

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -86,6 +86,8 @@ class BigBlueButtonTest extends TestCase
     // Create Meeting
 
     /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     *
      * Test create meeting URL.
      */
     public function testCreateMeetingUrl(): void
@@ -174,6 +176,8 @@ class BigBlueButtonTest extends TestCase
     // Join Meeting
 
     /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     *
      * Test create join meeting URL.
      */
     public function testCreateJoinMeetingUrl(): void
@@ -226,6 +230,8 @@ class BigBlueButtonTest extends TestCase
     // End Meeting
 
     /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     *
      * Test generate end meeting URL.
      */
     public function testCreateEndMeetingUrl(): void
@@ -266,6 +272,9 @@ class BigBlueButtonTest extends TestCase
 
     // Get Meetings
 
+    /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     */
     public function testGetMeetingsUrl(): void
     {
         $url = $this->bbb->getMeetingsUrl();
@@ -284,6 +293,9 @@ class BigBlueButtonTest extends TestCase
 
     // Get meeting info
 
+    /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     */
     public function testGetMeetingInfoUrl(): void
     {
         $meeting = $this->createRealMeeting($this->bbb);
@@ -301,6 +313,11 @@ class BigBlueButtonTest extends TestCase
         $this->assertTrue($result->success());
     }
 
+    // Get Recordings
+
+    /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     */
     public function testGetRecordingsUrl(): void
     {
         $url = $this->bbb->getRecordingsUrl(new GetRecordingsParameters());
@@ -314,6 +331,9 @@ class BigBlueButtonTest extends TestCase
         $this->assertTrue($result->success());
     }
 
+    /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     */
     public function testPublishRecordingsUrl(): void
     {
         $url = $this->bbb->getPublishRecordingsUrl(new PublishRecordingsParameters($this->faker->sha1, true));
@@ -327,6 +347,9 @@ class BigBlueButtonTest extends TestCase
         $this->assertTrue($result->failed());
     }
 
+    /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     */
     public function testDeleteRecordingsUrl(): void
     {
         $url = $this->bbb->getDeleteRecordingsUrl(new DeleteRecordingsParameters($this->faker->sha1));
@@ -340,6 +363,9 @@ class BigBlueButtonTest extends TestCase
         $this->assertTrue($result->failed());
     }
 
+    /**
+     * @deprecated Test will be removed together with the deprecated function from BigBlueButton::class
+     */
     public function testUpdateRecordingsUrl(): void
     {
         $params         = $this->generateUpdateRecordingsParams();

--- a/tests/Util/UrlBuilderTest.php
+++ b/tests/Util/UrlBuilderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2024 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Util;
+
+use BigBlueButton\Core\ApiMethod;
+use BigBlueButton\Enum\HashingAlgorithm;
+use BigBlueButton\Parameters\DeleteRecordingsParameters;
+use BigBlueButton\Parameters\GetMeetingInfoParameters;
+use BigBlueButton\Parameters\GetRecordingsParameters;
+use BigBlueButton\Parameters\PublishRecordingsParameters;
+use BigBlueButton\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class UrlBuilderTest extends TestCase
+{
+    private UrlBuilder $urlBuilder;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->urlBuilder = new UrlBuilder('any text', 'any text', HashingAlgorithm::SHA_256);
+    }
+
+    public function testCreateMeetingUrl(): void
+    {
+        $params = $this->generateCreateParams();
+        $url    = $this->urlBuilder->getCreateMeetingUrl($this->getCreateMock($params));
+
+        $paramsIterator = new ParamsIterator();
+        $paramsIterator->iterate($params, $url);
+    }
+
+    public function testCreateJoinMeetingUrl(): void
+    {
+        $joinMeetingParams = $this->generateJoinMeetingParams();
+
+        $joinMeetingMock = $this->getJoinMeetingMock($joinMeetingParams);
+
+        $url            = $this->urlBuilder->getJoinMeetingURL($joinMeetingMock);
+        $paramsIterator = new ParamsIterator();
+        $paramsIterator->iterate($joinMeetingParams, $url);
+    }
+
+    public function testCreateEndMeetingUrl(): void
+    {
+        $params         = $this->generateEndMeetingParams();
+        $url            = $this->urlBuilder->getEndMeetingURL($this->getEndMeetingMock($params));
+        $paramsIterator = new ParamsIterator();
+        $paramsIterator->iterate($params, $url);
+    }
+
+    public function testGetMeetingsUrl(): void
+    {
+        $url = $this->urlBuilder->getMeetingsUrl();
+        $this->assertStringContainsString(ApiMethod::GET_MEETINGS, $url);
+    }
+
+    public function testGetMeetingInfoUrl(): void
+    {
+        $meetingId = '12345678';
+
+        $url = $this->urlBuilder->getMeetingInfoUrl(new GetMeetingInfoParameters(urldecode($meetingId)));
+        $this->assertStringContainsString('=' . urlencode($meetingId), $url);
+    }
+
+    public function testGetRecordingsUrl(): void
+    {
+        $url = $this->urlBuilder->getRecordingsUrl(new GetRecordingsParameters());
+        $this->assertStringContainsString(ApiMethod::GET_RECORDINGS, $url);
+    }
+
+    public function testPublishRecordingsUrl(): void
+    {
+        $url = $this->urlBuilder->getPublishRecordingsUrl(new PublishRecordingsParameters($this->faker->sha1, true));
+        $this->assertStringContainsString(ApiMethod::PUBLISH_RECORDINGS, $url);
+    }
+
+    public function testDeleteRecordingsUrl(): void
+    {
+        $url = $this->urlBuilder->getDeleteRecordingsUrl(new DeleteRecordingsParameters($this->faker->sha1));
+        $this->assertStringContainsString(ApiMethod::DELETE_RECORDINGS, $url);
+    }
+
+    public function testUpdateRecordingsUrl(): void
+    {
+        $params         = $this->generateUpdateRecordingsParams();
+        $url            = $this->urlBuilder->getUpdateRecordingsUrl($this->getUpdateRecordingsParamsMock($params));
+        $paramsIterator = new ParamsIterator();
+        $paramsIterator->iterate($params, $url);
+    }
+}


### PR DESCRIPTION
## Background
The current main class `BigBlueButton::class` is currently pretty messy. It should only provide the main-functions for the handling with a BBB-Server. (SOLID - Seperation of Concern)

## Proposal
This PR 
- is shifting all the URL-generators from the `BigBlueButton::class` to the `UrlBuilder::class`
- previous URL-generators in `BigBlueButton::class` are marked as deprecated to support backward-compatibility and shall be removed with a next major release of this repository.
- previous URL-generators in `BigBlueButton::class` are adapted to use the new function from `UrlBuilder::class`
- is shifting all the tests of URL-generators from the `BigBlueButtonTest::class` into the new `UrlBuilderTest::class`.
- previous test of URL-generators in `BigBlueButtonTest::class` are marked as deprecated and shall be removed  too when related functions have been removed from `BigBlueButton::class`
- will remove the 3rd argument from private function `BigBlueButton::processXmlResponse`, as the name of the function determines already its supported type. Changing the type by the 3rd argument shall not be supported
- will remove the 3rd argument from private function `BigBlueButton::processJsonResponse`, as the name of the function determines already its supported type. Changing the type by the 3rd argument shall not be supported

