### PR TITLE
Replace deprecated lockSettingsDisableNote by lockSettingsDisableNotes

### DIFF
--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -79,7 +79,7 @@ class CreateMeetingParameters extends MetaParameters
 
     private ?bool $lockSettingsDisablePublicChat = null;
 
-    private ?bool $lockSettingsDisableNote = null;
+    private ?bool $lockSettingsDisableNotes = null;
 
     private ?bool $lockSettingsHideUserList = null;
 
@@ -780,9 +780,29 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
+    /**
+     * @deprecated isLockSettingsDisableNote is replaced by isLockSettingsDisableNotes
+     */
     public function isLockSettingsDisableNote(): ?bool
     {
-        return $this->lockSettingsDisableNote;
+        return $this->lockSettingsDisableNotes;
+    }
+
+    /**
+     * Setting to true will disable notes in the meeting.
+     *
+     * @deprecated setLockSettingsDisableNote is replaced by setLockSettingsDisableNotes
+     */
+    public function setLockSettingsDisableNote(bool $lockSettingsDisableNote): self
+    {
+        $this->setLockSettingsDisableNotes($lockSettingsDisableNote);
+
+        return $this;
+    }
+
+    public function isLockSettingsDisableNotes(): ?bool
+    {
+        return $this->lockSettingsDisableNotes;
     }
 
     /**
@@ -792,9 +812,9 @@ class CreateMeetingParameters extends MetaParameters
      *
      * @since 2.2
      */
-    public function setLockSettingsDisableNote(bool $lockSettingsDisableNote): self
+    public function setLockSettingsDisableNotes(bool $lockSettingsDisableNotes): self
     {
-        $this->lockSettingsDisableNote = $lockSettingsDisableNote;
+        $this->lockSettingsDisableNotes = $lockSettingsDisableNotes;
 
         return $this;
     }
@@ -1424,7 +1444,7 @@ class CreateMeetingParameters extends MetaParameters
             'lockSettingsDisableMic'                 => !is_null($this->lockSettingsDisableMic) ? ($this->lockSettingsDisableMic ? 'true' : 'false') : $this->lockSettingsDisableMic,
             'lockSettingsDisablePrivateChat'         => !is_null($this->lockSettingsDisablePrivateChat) ? ($this->lockSettingsDisablePrivateChat ? 'true' : 'false') : $this->lockSettingsDisablePrivateChat,
             'lockSettingsDisablePublicChat'          => !is_null($this->lockSettingsDisablePublicChat) ? ($this->lockSettingsDisablePublicChat ? 'true' : 'false') : $this->lockSettingsDisablePublicChat,
-            'lockSettingsDisableNote'                => !is_null($this->lockSettingsDisableNote) ? ($this->lockSettingsDisableNote ? 'true' : 'false') : $this->lockSettingsDisableNote,
+            'lockSettingsDisableNotes'               => !is_null($this->lockSettingsDisableNotes) ? ($this->lockSettingsDisableNotes ? 'true' : 'false') : $this->lockSettingsDisableNotes,
             'lockSettingsHideUserList'               => !is_null($this->lockSettingsHideUserList) ? ($this->lockSettingsHideUserList ? 'true' : 'false') : $this->lockSettingsHideUserList,
             'lockSettingsLockedLayout'               => !is_null($this->lockSettingsLockedLayout) ? ($this->lockSettingsLockedLayout ? 'true' : 'false') : $this->lockSettingsLockedLayout,
             'lockSettingsLockOnJoin'                 => !is_null($this->lockSettingsLockOnJoin) ? ($this->lockSettingsLockOnJoin ? 'true' : 'false') : $this->lockSettingsLockOnJoin,

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -785,7 +785,7 @@ class CreateMeetingParameters extends MetaParameters
      */
     public function isLockSettingsDisableNote(): ?bool
     {
-        return $this->lockSettingsDisableNotes;
+        return $this->isLockSettingsDisableNotes();
     }
 
     /**

--- a/src/Parameters/DocumentableTrait.php
+++ b/src/Parameters/DocumentableTrait.php
@@ -37,12 +37,12 @@ trait DocumentableTrait
         return $this->presentations;
     }
 
-    public function addPresentation(string $nameOrUrl, $content = null, ?string $filename = null, DocumentOptionsStore $attributes = null): self
+    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, DocumentOptionsStore $attributes = null): self
     {
         $this->presentations[$nameOrUrl] = [
-            'content' => !$content ?: base64_encode($content),
-            'filename' => $filename,
-            'attributes' => $attributes
+            'content'    => $content ? base64_encode($content) : null,
+            'filename'   => $filename,
+            'attributes' => $attributes,
         ];
 
         return $this;
@@ -73,8 +73,10 @@ trait DocumentableTrait
                 }
 
                 // Add attributes using DocumentAttributes class
-                foreach ($data['attributes']->getAttributes() as $attrName => $attrValue) {
-                    $presentation->addAttribute($attrName, $attrValue);
+                if (!empty($data['attributes'])) {
+                    foreach ($data['attributes']->getAttributes() as $attrName => $attrValue) {
+                        $presentation->addAttribute($attrName, $attrValue);
+                    }
                 }
             }
             $result = $xml->asXML();

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -33,7 +33,6 @@ use BigBlueButton\Parameters\PublishRecordingsParameters;
 use BigBlueButton\TestServices\EnvLoader;
 use BigBlueButton\TestServices\Fixtures;
 use BigBlueButton\TestServices\ParamsIterator;
-use Tracy\Debugger;
 
 /**
  * Class BigBlueButtonTest.

--- a/tests/BigBlueButtonTest.php
+++ b/tests/BigBlueButtonTest.php
@@ -33,6 +33,7 @@ use BigBlueButton\Parameters\PublishRecordingsParameters;
 use BigBlueButton\TestServices\EnvLoader;
 use BigBlueButton\TestServices\Fixtures;
 use BigBlueButton\TestServices\ParamsIterator;
+use Tracy\Debugger;
 
 /**
  * Class BigBlueButtonTest.

--- a/tests/Parameters/CreateMeetingParametersTest.php
+++ b/tests/Parameters/CreateMeetingParametersTest.php
@@ -59,7 +59,8 @@ class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($params['lockSettingsDisableMic'], $createMeetingParams->isLockSettingsDisableMic());
         $this->assertEquals($params['lockSettingsDisablePrivateChat'], $createMeetingParams->isLockSettingsDisablePrivateChat());
         $this->assertEquals($params['lockSettingsDisablePublicChat'], $createMeetingParams->isLockSettingsDisablePublicChat());
-        $this->assertEquals($params['lockSettingsDisableNote'], $createMeetingParams->isLockSettingsDisableNote());
+        $this->assertEquals($params['lockSettingsDisableNotes'], $createMeetingParams->isLockSettingsDisableNote());
+        $this->assertEquals($params['lockSettingsDisableNotes'], $createMeetingParams->isLockSettingsDisableNotes());
         $this->assertEquals($params['lockSettingsHideUserList'], $createMeetingParams->isLockSettingsHideUserList());
         $this->assertEquals($params['lockSettingsLockedLayout'], $createMeetingParams->isLockSettingsLockedLayout());
         $this->assertEquals($params['lockSettingsLockOnJoin'], $createMeetingParams->isLockSettingsLockOnJoin());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -175,7 +175,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
             'lockSettingsDisableMic'                 => $this->faker->boolean(50),
             'lockSettingsDisablePrivateChat'         => $this->faker->boolean(50),
             'lockSettingsDisablePublicChat'          => $this->faker->boolean(50),
-            'lockSettingsDisableNote'                => $this->faker->boolean(50),
+            'lockSettingsDisableNotes'               => $this->faker->boolean(50),
             'lockSettingsHideUserList'               => $this->faker->boolean(50),
             'lockSettingsLockedLayout'               => $this->faker->boolean(50),
             'lockSettingsLockOnJoin'                 => $this->faker->boolean(50),
@@ -284,7 +284,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
             ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])
             ->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
             ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])
-            ->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
+            ->setLockSettingsDisableNote($params['lockSettingsDisableNotes'])
+            ->setLockSettingsDisableNotes($params['lockSettingsDisableNotes'])
             ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])
             ->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
             ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])

--- a/tests/TestServices/Fixtures.php
+++ b/tests/TestServices/Fixtures.php
@@ -107,7 +107,7 @@ class Fixtures
             'lockSettingsDisableMic'                 => $faker->boolean(50),
             'lockSettingsDisablePrivateChat'         => $faker->boolean(50),
             'lockSettingsDisablePublicChat'          => $faker->boolean(50),
-            'lockSettingsDisableNote'                => $faker->boolean(50),
+            'lockSettingsDisableNotes'               => $faker->boolean(50),
             'lockSettingsHideUserList'               => $faker->boolean(50),
             'lockSettingsLockedLayout'               => $faker->boolean(50),
             'lockSettingsLockOnJoin'                 => $faker->boolean(50),
@@ -269,7 +269,8 @@ class Fixtures
             ->setLockSettingsDisableMic($params['lockSettingsDisableMic'])
             ->setLockSettingsDisablePrivateChat($params['lockSettingsDisablePrivateChat'])
             ->setLockSettingsDisablePublicChat($params['lockSettingsDisablePublicChat'])
-            ->setLockSettingsDisableNote($params['lockSettingsDisableNote'])
+            ->setLockSettingsDisableNote($params['lockSettingsDisableNotes'])
+            ->setLockSettingsDisableNotes($params['lockSettingsDisableNotes'])
             ->setLockSettingsHideUserList($params['lockSettingsHideUserList'])
             ->setLockSettingsLockedLayout($params['lockSettingsLockedLayout'])
             ->setLockSettingsLockOnJoin($params['lockSettingsLockOnJoin'])


### PR DESCRIPTION
Solve bug (deprecation message) reported by issue #229

**Background**
BBB-Server reports a deprecation warning for `lockSettingsDisableNote`. 
According to documentation `lockSettingsDisableNotes` was introduced with API version 2.2.

Must have been always an unsolved typo.