### PR TITLE
Implement CaptainHook

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
  * with BigBlueButton; if not, see <https://www.gnu.org/licenses/>.
  */
 
+use BigBlueButton\Util\StrlenFixer;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
@@ -53,6 +54,9 @@ $finder = Finder::create()
 $config = new Config();
 $config
     ->setRiskyAllowed(true)
+    ->registerCustomFixers([
+        new StrlenFixer(),
+    ])
     ->setRules([
         '@PhpCsFixer'                      => true,
         '@PHP74Migration'                  => true,
@@ -71,6 +75,7 @@ $config
             ],
         ],
         'php_unit_test_class_requires_covers' => false,
+        'BigBlueButton/do_not_change_strlen'  => true,
     ])
     ->setFinder($finder)
 ;

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Make sure the code style configuration is applied by running PHPCS-Fixer.
 
 ```bash
 # using an alias
-$ composer cs-fix
+$ composer code-fix
+
+# or the same w/o alias
+$ PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --allow-risky yes
 ```
 
 ### Code Quality 2: Static code analysis
@@ -88,6 +91,21 @@ can specify your own BBB-server by copy that file into the same folder and name 
 Exchange the credentials `BBB_SERVER_BASE_URL` and `BBB_SECRET` to your server's values.
 Since this new file (`.env.local`) takes precedence over the main file (`.env`), you will now test 
 with your own server.
+
+### Automated checks while commiting a change
+To ensure code quality, a took called [CaptainHook](https://github.com/captainhookphp/captainhook?tab=readme-ov-file) will be launched when you are commiting a change and will intercept the commit, if the quality is not as expected. Once the quality of the code is improved the code can be commited (CaptainHook will check again).
+
+Automated checks:
+1) Correct commit Message ([beams](https://cbea.ms/git-commit/)): Starting with capital letter, max. 50 characters and imperative mood (e.g. This change will: 'Refactor subsystem X for readability').
+2) Style: The code style will be checked with PHPCS-Fixer (same as above `composer code-fix`)
+3) Static Analyse: The code will be checked with PHPStan (same as above `composer code-check`)
+4) Test: PHPUnit will be executed to ensure the code is working (same as above `composer code-test`)
+
+> **Tip:** To avoid interceptions by CaptainHook it is recommended to run the three commands prior your commit in order to pre-check the code quality.
+
+> **Danger:** Please avoid the deactivation of the automated checks by using the git flag `--no-verify` while commiting.
+
+> **Remark:** CaptainHook should be activated automatically with the first composer command (say `yes` to all questions). If you want to active it manually with `vendor/bin/captainhook install`.
 
 [bbb]: http://bigbluebutton.org
 [composer]: https://getcomposer.org

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,0 +1,59 @@
+{
+    "commit-msg": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Beams",
+                "options": {
+                    "subjectLength": 50,
+                    "bodyLineLength": 72
+                }
+            }
+        ]
+    },
+    "pre-push": {
+        "enabled": false,
+        "actions": []
+    },
+    "pre-commit": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "\\CaptainHook\\App\\Hook\\PHP\\Action\\Linting"
+            },
+            {
+                "action": "composer code-fix -- --dry-run --verbose --show-progress=none"
+            },
+            {
+                "action": "composer code-check"
+            },
+            {
+                "action": "composer code-test -- --stop-on-failure"
+            }
+        ]
+    },
+    "prepare-commit-msg": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-commit": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-merge": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-checkout": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-rewrite": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-change": {
+        "enabled": false,
+        "actions": []
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,14 @@
     "phpstan/phpstan": "^1.10",
     "tracy/tracy": "^2.10",
     "vlucas/phpdotenv": "^5.6",
-    "phpunit/php-code-coverage": "^10.1"
+    "phpunit/php-code-coverage": "^10.1",
+    "captainhook/captainhook": "^5.23",
+    "captainhook/hook-installer": "^1.0"
   },
   "scripts": {
     "code-check": "./vendor/bin/phpstan analyse",
     "code-test": "./vendor/bin/phpunit",
-    "cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --allow-risky yes",
+    "code-fix": "PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --allow-risky yes",
     "sniffer": "./vendor/bin/phpcs src/",
     "phpinsights": "./vendor/bin/phpinsights",
     "phpdd": "./vendor/bin/phpdd --target 8.0 src/",
@@ -70,7 +72,9 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "captainhook/captainhook-phar": true,
+      "captainhook/hook-installer": true
     }
   }
 }

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -566,7 +566,7 @@ class BigBlueButton
             curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
             curl_setopt($ch, CURLOPT_HTTPHEADER, [
                 'Content-type: ' . $contentType,
-                'Content-length: ' . strlen($payload),
+                'Content-length: ' . mb_strlen($payload),
             ]);
         }
 

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -566,7 +566,7 @@ class BigBlueButton
             curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
             curl_setopt($ch, CURLOPT_HTTPHEADER, [
                 'Content-type: ' . $contentType,
-                'Content-length: ' . mb_strlen($payload),
+                'Content-length: ' . strlen($payload),
             ]);
         }
 

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -1244,7 +1244,7 @@ class CreateMeetingParameters extends MetaParameters
 
     /**
      * If passed with a valid presentation file url, this presentation will override the default presentation.
-     * To only upload but not set as default, also pass preUploadedPresentationOverrideDefault=false
+     * To only upload but not set as default, also pass preUploadedPresentationOverrideDefault=false.
      *
      * @since 2.7.2
      */
@@ -1256,7 +1256,7 @@ class CreateMeetingParameters extends MetaParameters
     }
 
     /**
-     * If passed it will use this string as the name of the presentation uploaded via preUploadedPresentation
+     * If passed it will use this string as the name of the presentation uploaded via preUploadedPresentation.
      *
      * @since 2.7.2
      */

--- a/src/Parameters/DocumentableTrait.php
+++ b/src/Parameters/DocumentableTrait.php
@@ -37,7 +37,7 @@ trait DocumentableTrait
         return $this->presentations;
     }
 
-    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, DocumentOptions $documentOptions = null): self
+    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?DocumentOptions $documentOptions = null): self
     {
         $this->presentations[$nameOrUrl] = [
             'content'         => $content ? base64_encode($content) : null,

--- a/src/Util/StrlenFixer.php
+++ b/src/Util/StrlenFixer.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2024 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Util;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+class StrlenFixer implements FixerInterface
+{
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        // Replace the line 'Content-length: ' . mb_strlen($payload), with 'Content-length: ' . strlen($payload),
+        foreach ($tokens as $index => $token) {
+            if (null === $token) {
+                continue;
+            }
+
+            // check if token has expected string
+            if (!str_contains($token->getContent(), "'Content-length:")) {
+                continue;
+            }
+
+            // check if next token is '.'
+            $nextTokenPosition = $tokens->getNextMeaningfulToken($index);
+            if (null === $nextTokenPosition) {
+                continue;
+            }
+            $nextToken = $tokens[$nextTokenPosition];
+            if ('.' !== $nextToken->getContent()) {
+                continue;
+            }
+
+            // check if next token is 'mb_strlen'
+            $nextTokenPosition = $tokens->getNextMeaningfulToken($nextTokenPosition);
+            if (null === $nextTokenPosition) {
+                continue;
+            }
+            $nextToken = $tokens[$nextTokenPosition];
+            if ('mb_strlen' !== $nextToken->getContent()) {
+                continue;
+            }
+
+            // We have a match: Adapt the token
+            $tokens[$nextTokenPosition] = new Token([T_STRING, 'strlen']);
+        }
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Will ensure that strlen() is not replaced by mb_strlen().',
+            [
+                new CodeSample('<?php // not example yet'),
+            ]
+        );
+    }
+
+    public function getName(): string
+    {
+        return 'BigBlueButton/do_not_change_strlen';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file): bool
+    {
+        if (basename(__FILE__) === basename($file)) {
+            return false; // ensure this file is not changed by itself
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This PR will

- implement CaptainHook
- update documentation regarding captain hook
- close issue #243 
- introduce Custom Code Fixer (for PHP CS-Fixer) to prevent change of `strlen` by `mb_strlen` in the context of `Content-length` (see issue #118) 