### PR TITLE
Simplify BigBlueButton::processJsonResponse, drop parameter

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -624,8 +624,8 @@ class BigBlueButton
      *
      * @throws BadResponseException
      */
-    private function processJsonResponse(string $url, string $payload = ''): string
+    private function processJsonResponse(string $url): string
     {
-        return $this->sendRequest($url, $payload, 'application/json');
+        return $this->sendRequest($url, contentType: 'application/json');
     }
 }


### PR DESCRIPTION
That parameter is always `''` as correctly pointed out by my IDE.
It's a private method, so...

(This is baseline for further changes)