### PR TITLE
Fix PHP 8.4 / 8.5 deprecations (implicit nullable params, curl_close)

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -603,8 +603,10 @@ class BigBlueButton
             throw new BadResponseException('Bad response, HTTP code: ' . $httpCode . ', url: ' . $url);
         }
 
-        // CLOSE AND UNSET
-        curl_close($ch);
+        // UNSET
+        // Note: curl_close() is intentionally omitted. Since PHP 8.0 the curl handle is a
+        // CurlHandle object that is freed automatically by the garbage collector once unset,
+        // curl_close() has no effect and was deprecated in PHP 8.5.
         unset($ch);
 
         // RETURN

--- a/src/Parameters/DeleteRecordingsParameters.php
+++ b/src/Parameters/DeleteRecordingsParameters.php
@@ -27,7 +27,7 @@ class DeleteRecordingsParameters extends BaseParameters
 {
     private ?string $recordingId = null;
 
-    public function __construct(string $recordingId = null)
+    public function __construct(?string $recordingId = null)
     {
         $this->recordingId = $recordingId;
     }

--- a/src/Parameters/DocumentableTrait.php
+++ b/src/Parameters/DocumentableTrait.php
@@ -73,8 +73,10 @@ trait DocumentableTrait
                 }
 
                 // Add attributes using DocumentAttributes class
-                foreach ($data['attributes']->getAttributes() as $attrName => $attrValue) {
-                    $presentation->addAttribute($attrName, $attrValue);
+                if ($data['attributes'] instanceof DocumentOptionsStore) {
+                    foreach ($data['attributes']->getAttributes() as $attrName => $attrValue) {
+                        $presentation->addAttribute($attrName, $attrValue);
+                    }
                 }
             }
             $result = $xml->asXML();

--- a/src/Parameters/DocumentableTrait.php
+++ b/src/Parameters/DocumentableTrait.php
@@ -40,7 +40,7 @@ trait DocumentableTrait
     public function addPresentation(string $nameOrUrl, $content = null, ?string $filename = null, ?DocumentOptionsStore $attributes = null): self
     {
         $this->presentations[$nameOrUrl] = [
-            'content' => !$content ?: base64_encode($content),
+            'content' => null !== $content ? base64_encode($content) : null,
             'filename' => $filename,
             'attributes' => $attributes
         ];

--- a/src/Parameters/DocumentableTrait.php
+++ b/src/Parameters/DocumentableTrait.php
@@ -37,7 +37,7 @@ trait DocumentableTrait
         return $this->presentations;
     }
 
-    public function addPresentation(string $nameOrUrl, $content = null, ?string $filename = null, DocumentOptionsStore $attributes = null): self
+    public function addPresentation(string $nameOrUrl, $content = null, ?string $filename = null, ?DocumentOptionsStore $attributes = null): self
     {
         $this->presentations[$nameOrUrl] = [
             'content' => !$content ?: base64_encode($content),

--- a/src/Parameters/EndMeetingParameters.php
+++ b/src/Parameters/EndMeetingParameters.php
@@ -32,7 +32,7 @@ class EndMeetingParameters extends BaseParameters
      */
     private ?string $password = null;
 
-    public function __construct(string $meetingId = null, string $password = null)
+    public function __construct(?string $meetingId = null, ?string $password = null)
     {
         $this->password  = $password;
         $this->meetingId = $meetingId;

--- a/src/Parameters/GetRecordingTextTracksParameters.php
+++ b/src/Parameters/GetRecordingTextTracksParameters.php
@@ -30,7 +30,7 @@ class GetRecordingTextTracksParameters extends MetaParameters
     /**
      * GetRecordingTextTracksParameters constructor.
      */
-    public function __construct(string $recordId = null)
+    public function __construct(?string $recordId = null)
     {
         $this->recordId = $recordId;
     }

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -29,7 +29,7 @@ class InsertDocumentParameters extends BaseParameters
 
     private ?string $meetingId = null;
 
-    public function __construct(string $meetingId = null)
+    public function __construct(?string $meetingId = null)
     {
         $this->meetingId = $meetingId;
     }

--- a/src/Parameters/IsMeetingRunningParameters.php
+++ b/src/Parameters/IsMeetingRunningParameters.php
@@ -27,7 +27,7 @@ class IsMeetingRunningParameters extends BaseParameters
 {
     private ?string $meetingId = null;
 
-    public function __construct(string $meetingId = null)
+    public function __construct(?string $meetingId = null)
     {
         $this->meetingId = $meetingId;
     }

--- a/src/Parameters/PutRecordingTextTrackParameters.php
+++ b/src/Parameters/PutRecordingTextTrackParameters.php
@@ -36,7 +36,7 @@ class PutRecordingTextTrackParameters extends BaseParameters
     /**
      * PutRecordingTextTrackParameters constructor.
      */
-    public function __construct(string $recordId = null, string $kind = null, string $lang = null, string $label = null)
+    public function __construct(?string $recordId = null, ?string $kind = null, ?string $lang = null, ?string $label = null)
     {
         $this->recordId = $recordId;
         $this->kind     = $kind;

--- a/src/Parameters/UpdateRecordingsParameters.php
+++ b/src/Parameters/UpdateRecordingsParameters.php
@@ -27,7 +27,7 @@ class UpdateRecordingsParameters extends MetaParameters
 {
     private ?string $recordingId = null;
 
-    public function __construct(string $recordingId = null)
+    public function __construct(?string $recordingId = null)
     {
         $this->recordingId = $recordingId;
     }


### PR DESCRIPTION
This makes the library clean under PHP 8.4 and 8.5 with a minimal, behaviour-preserving diff (the curl transport is otherwise untouched).

## PHP 8.4 — implicit nullable parameters
Parameters typed `string $x = null` are implicitly nullable, which is deprecated in PHP 8.4. Added an explicit `?` to all affected signatures:

- `EndMeetingParameters::__construct()`
- `IsMeetingRunningParameters::__construct()`
- `DeleteRecordingsParameters::__construct()`
- `UpdateRecordingsParameters::__construct()`
- `InsertDocumentParameters::__construct()`
- `GetRecordingTextTracksParameters::__construct()`
- `PutRecordingTextTrackParameters::__construct()`
- `DocumentableTrait::addPresentation()` (`$attributes`)

## PHP 8.5 — curl_close()
`curl_close()` is deprecated as of PHP 8.5 (it has had no effect since PHP 8.0, where the curl handle became a `CurlHandle` object freed by the garbage collector). Removed the call in `sendRequest()`.

## Bonus: presentation serialization fixes
While adding `?` to `addPresentation()` I noticed `getPresentationsAsXML()` was broken for presentations added without attributes/content (the existing `tests/Parameters` cases for URL/file presentations errored):

- `null->getAttributes()` fatal when no `DocumentOptionsStore` was passed → now guarded.
- URL-only documents serialized as `<document url="...">1</document>`, because `!$content ?: base64_encode($content)` yields `true` for `null` content → now stored as `null`.

These two one-liners turn the previously red `tests/Parameters` presentation tests green. Happy to split them into a separate PR if preferred.

## Verification
- `php -l` clean on all files (PHP 8.5)
- Deprecation reproduction: emitted before, clean after
- `tests/Parameters` + `tests/Responses`: 18/18 green
